### PR TITLE
Fix challenge mode absolute bar to support time label

### DIFF
--- a/client/src/graphics/Stack.lua
+++ b/client/src/graphics/Stack.lua
@@ -607,7 +607,7 @@ function Stack:drawMultibar()
 
   if self.theme.multibar_is_absolute then
     -- absolute multibar is *only* supported for v3 themes
-    self:drawAbsoluteMultibar(stop_time, shake_time)
+    self:drawAbsoluteMultibar(stop_time, shake_time, self.pre_stop_time)
   else
     self:drawRelativeMultibar(stop_time, shake_time)
   end

--- a/common/engine/SimulatedStack.lua
+++ b/common/engine/SimulatedStack.lua
@@ -292,7 +292,7 @@ end
 
 function SimulatedStack:drawMultibar()
   if self.health then
-    self:drawAbsoluteMultibar(0, 0)
+    self:drawAbsoluteMultibar(0, 0, 0)
   end
 end
 

--- a/common/engine/StackBase.lua
+++ b/common/engine/StackBase.lua
@@ -306,10 +306,10 @@ function StackBase:drawCanvas()
   love.graphics.setBlendMode("alpha", "alphamultiply")
 end
 
-function StackBase:drawAbsoluteMultibar(stop_time, shake_time, framePos, barPos, overtimePos)
-  framePos = framePos or themes[config.theme].healthbar_frame_Pos
-  barPos = barPos or themes[config.theme].multibar_Pos
-  overtimePos = overtimePos or themes[config.theme].multibar_LeftoverTime_Pos
+function StackBase:drawAbsoluteMultibar(stop_time, shake_time, pre_stop_time)
+  local framePos = themes[config.theme].healthbar_frame_Pos
+  local barPos = themes[config.theme].multibar_Pos
+  local overtimePos = themes[config.theme].multibar_LeftoverTime_Pos
 
   self:drawLabel(themes[config.theme].images.healthbarFrames.absolute[self.which], framePos, themes[config.theme].healthbar_frame_Scale * (self.gfxScale / 3))
 
@@ -318,6 +318,7 @@ function StackBase:drawAbsoluteMultibar(stop_time, shake_time, framePos, barPos,
   local bottomOffset = 0
 
   local healthHeight = (self.health / multiBarFrameCount) * multiBarMaxHeight
+  healthHeight = math.min(healthHeight, multiBarMaxHeight)
   self:drawBar(themes[config.theme].images.IMG_healthbar, self.healthQuad, barPos, healthHeight, 0, 0, themes[config.theme].multibar_Scale)
 
   bottomOffset = healthHeight
@@ -325,7 +326,7 @@ function StackBase:drawAbsoluteMultibar(stop_time, shake_time, framePos, barPos,
   local stopHeight = 0
   local preStopHeight = 0
 
-  if shake_time > 0 and shake_time > (stop_time + self.pre_stop_time) then
+  if shake_time > 0 and shake_time > (stop_time + pre_stop_time) then
     -- shake is only drawn if it is greater than prestop + stop
     -- shake is always guaranteed to fit
     local shakeHeight = (shake_time / multiBarFrameCount) * multiBarMaxHeight
@@ -338,22 +339,23 @@ function StackBase:drawAbsoluteMultibar(stop_time, shake_time, framePos, barPos,
 
       bottomOffset = bottomOffset + stopHeight
     end
-    if self.pre_stop_time and self.pre_stop_time > 0 then
-      local totalInvincibility = self.health + self.stop_time + self.pre_stop_time
-      local remainingSeconds = 0
-      if totalInvincibility > multiBarFrameCount then
-        -- total invincibility exceeds what the multibar can display -> fill only the remaining space with prestop
-        preStopHeight = (1 - (self.health + stop_time) / multiBarFrameCount) * multiBarMaxHeight
-        remainingSeconds = (totalInvincibility - multiBarFrameCount) / 60
-      else
-        preStopHeight = self.pre_stop_time / multiBarFrameCount * multiBarMaxHeight
-      end
 
+    local totalInvincibility = self.health + stop_time + pre_stop_time
+    local remainingSeconds = 0
+    if totalInvincibility > multiBarFrameCount then
+      -- total invincibility exceeds what the multibar can display -> fill only the remaining space with prestop
+      preStopHeight = (1 - (self.health + stop_time) / multiBarFrameCount) * multiBarMaxHeight
+      remainingSeconds = (totalInvincibility - multiBarFrameCount) / 60
+    else
+      preStopHeight = pre_stop_time / multiBarFrameCount * multiBarMaxHeight
+    end
+
+    if pre_stop_time and pre_stop_time > 0 then
       self:drawBar(themes[config.theme].images.IMG_multibar_prestop_bar, self.multi_prestopQuad, barPos, preStopHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
+    end
 
-      if remainingSeconds > 0 then
-        self:drawString(string.format("%." .. themes[config.theme].multibar_LeftoverTime_Decimals .. "f", remainingSeconds), overtimePos, false, 20)
-      end
+    if remainingSeconds > 0 then
+      self:drawString(string.format("%." .. themes[config.theme].multibar_LeftoverTime_Decimals .. "f", remainingSeconds), overtimePos, false, 20)
     end
   end
 end


### PR DESCRIPTION
The challenge mode absolute bar didn't show the amount of time remaining on the label like it does in vs. Fixed.

Should the label show the actual time remaining instead of the amount remaining before the bar starts draining? To me it felt like the label should be total time.