### PR TITLE
fix(soundtest): sfx stepper

### DIFF
--- a/client/src/scenes/SoundTest.lua
+++ b/client/src/scenes/SoundTest.lua
@@ -92,6 +92,10 @@ function SoundTest:load()
 
         local labels, values = createSfxMenuInfo(value)
         sfxStepper:setLabels(labels, values, 1)
+        
+        -- redraw sfx stepper
+        self.soundTestMenu:removeMenuItemAtIndex(5);
+        self.soundTestMenu:addMenuItem(5, MenuItem.createStepperMenuItem("op_music_sfx", nil, nil, sfxStepper))
 
         if playButtonGroup.value == "character" then
           playMusic("character", value, musicTypeButtonGroup.value)
@@ -201,9 +205,9 @@ function SoundTest:load()
     end)
   }
   
-  soundTestMenu = Menu.createCenteredMenu(soundTestMenuOptions)
+  self.soundTestMenu = Menu.createCenteredMenu(soundTestMenuOptions)
 
-  self.uiRoot:addChild(soundTestMenu)
+  self.uiRoot:addChild(self.soundTestMenu)
   
   self.backgroundImg = themes[config.theme].images.bg_main
 
@@ -218,7 +222,7 @@ function SoundTest:load()
 end
 
 function SoundTest:update(dt)
-  soundTestMenu:receiveInputs()
+  self.soundTestMenu:receiveInputs()
   self.backgroundImg:update(dt)
 end
 

--- a/client/src/scenes/SoundTest.lua
+++ b/client/src/scenes/SoundTest.lua
@@ -22,8 +22,6 @@ SoundTest.name = "SoundTest"
 local BUTTON_WIDTH = 70
 local BUTTON_HEIGHT = 25
 
-local soundTestMenu
-
 local menuValidateSound
 
 local function playMusic(source, id, musicType)

--- a/client/src/ui/Stepper.lua
+++ b/client/src/ui/Stepper.lua
@@ -5,18 +5,38 @@ local TextButton = require("client.src.ui.TextButton")
 local Label = require("client.src.ui.Label")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 
+local NAV_BUTTON_WIDTH = 25
+local EMPTY_STEPPER_WIDTH = 160
+
 local function setLabels(self, labels, values, selectedIndex)
   self.selectedIndex = selectedIndex
   self.values = values
   self.labels = labels
+
+  self:removeLabelChildren()
+
+  if (#labels == 0) then
+    self.rightButton:setVisibility(false);
+    self.leftButton:setVisibility(false);
+    self.width = EMPTY_STEPPER_WIDTH
+    return
+  end
+
   for _, label in ipairs(labels) do
-    self:addChild(label)
-    label:setVisibility(false)
+      label.hAlign = "center"
+      label.vAlign = "center"
+      self.width = math.max(label.width + 10 + NAV_BUTTON_WIDTH * 2, self.width)
+      self.height = math.max(label.height + 4, self.height)
+
+      self:addChild(label)
+      label:setVisibility(false)
   end
-  if #self.labels > 0 then
-    self.labels[self.selectedIndex]:setVisibility(true)
-    self.value = self.values[self.selectedIndex]
-  end
+
+  self.labels[self.selectedIndex]:setVisibility(true)
+  self.value = self.values[self.selectedIndex]
+  self.rightButton.x = self.width - NAV_BUTTON_WIDTH
+  self.rightButton:setVisibility(true);
+  self.leftButton:setVisibility(true);
 end
 
 local function setState(self, i)
@@ -61,16 +81,6 @@ local Stepper = class(
     self.color = {.5, .5, 1, .7}
     self.borderColor = {.7, .7, 1, .7}
 
-    if #options.labels > 0 then
-      for i = 1, #options.labels do
-        options.labels[i].hAlign = "center"
-        options.labels[i].vAlign = "center"
-        self.width = math.max(options.labels[i].width + 10 + navButtonWidth * 2, self.width)
-        self.height = math.max(options.labels[i].height + 4, self.height)
-      end
-      self.rightButton.x = self.width - navButtonWidth
-    end
-
     setLabels(self, options.labels, options.values, self.selectedIndex)
 
     self.TYPE = "Stepper"
@@ -105,6 +115,13 @@ function Stepper:drawSelf()
     GraphicsUtil.setColor(self.borderColor)
     GraphicsUtil.drawRectangle("line", self.x, self.y, self.width, self.height)
     GraphicsUtil.setColor(1, 1, 1, 1)
+  end
+end
+
+-- Remove all attached labels, preserving the navigation buttons
+function Stepper:removeLabelChildren()
+  for i = #self.children, 3, -1 do
+    self.children[i]:detach()
   end
 end
 


### PR DESCRIPTION
Fixed steppers in general not properly clearing out labels, resizing and repositioning nav arrows on "setLabels". Also fixed SoundTest redrawing the SFX stepper after changes to the labels so the MenuItem resizes.

Fixes #575 