### PR TITLE
Potential Fix for rating crash

### DIFF
--- a/client/src/Player.lua
+++ b/client/src/Player.lua
@@ -238,7 +238,7 @@ function Player:setRating(rating)
   end
 
   if rating and tonumber(rating) then
-    rating = math.round(rating)
+    rating = math.round(tonumber(rating))
   end
 
   self.rating = rating


### PR DESCRIPTION
The tonumber is being accepted but not converted before rounded.

never reproduced the issue but should fix it.

Error: Please share your crash.log with the developers to get help with this!

Stack Trace: 
    common/lib/mathExtensions.lua:10: in function 'round'
    client/src/Player.lua:236: in function 'setRating'
    client/src/network/NetClient.lua:108: in function 'callback'
    client/src/network/MessageListener.lua:19: in function 'listen'
    client/src/network/NetClient.lua:594: in function 'update'
    client/src/Game.lua:371: in function 'update'
    main.lua:97: in function 'update'
    client/src/CustomRun.lua:124: in function 'runInternal'
    client/src/CustomRun.lua:210: in function <client/src/CustomRun.lua:208>
    [C]: in function 'xpcall'
Username: Dexirian2
Theme: Panel Attack Modern
Error Message: common/lib/mathExtensions.lua:10: attempt to compare number with string
Engine Version: 048
Build Version: stable 1737501050
Operating System: OS: Windows
Love Version: 12.0.0
Renderer Info: OpenGL;4.3.0 - Build 32.0.101.6078;Intel;Intel(R) Iris(R) Xe Graphics
UTC Time: 2025-01-21 20:45:27
Scene: GameBase