### PR TITLE
Fix crash when trying to manage mods after a theme switch

### DIFF
--- a/client/src/FileUtils.lua
+++ b/client/src/FileUtils.lua
@@ -122,6 +122,9 @@ function fileUtils.readJsonFile(file)
 end
 
 --returns a source, or nil if it could not find a file
+---@param path_and_filename string
+---@param streamed boolean?
+---@return love.Source?
 function fileUtils.loadSoundFromSupportExtensions(path_and_filename, streamed)
   for k, extension in ipairs(fileUtils.SUPPORTED_SOUND_FORMATS) do
     if love.filesystem.getInfo(path_and_filename .. extension) then
@@ -132,6 +135,10 @@ function fileUtils.loadSoundFromSupportExtensions(path_and_filename, streamed)
 end
 
 -- returns a new sound effect if it can be found, else returns nil
+---@param sound_name string the file name without extension we're looking for
+---@param dirs_to_check string[] the directories that are searched for the file
+---@param streamed boolean? true if the source should be loaded as a stream, false/nil if static
+---@return love.Source?
 function fileUtils.findSound(sound_name, dirs_to_check, streamed)
   streamed = streamed or false
   local found_source

--- a/client/src/mods/Stage.lua
+++ b/client/src/mods/Stage.lua
@@ -23,6 +23,14 @@ local other_musics = {"normal_music", "danger_music", "normal_music_start", "dan
 
 local randomStage = nil -- acts as the bundle stage for all theme stages
 
+---@class Stage : Mod
+---@field display_name string
+---@field music_style string defines the behaviour for music when switching between normal and danger
+---@field music_volume number defines a multiplier to apply to the StageTrack
+---@field images table<string, love.Image> graphical assets of the stage
+---@field musics table<string, love.Source> music assets of the stage
+---@field hasMusic boolean? if the stage has any music
+---@field stageTrack StageTrack? the StageTrack constructed from the stage's music assets
 local Stage =
   class(
   function(s, full_path, folder_name)

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -24,10 +24,6 @@ local flags = {
   "us" -- United States of America
 }
 
----@enum ThemeVersion
-local THEME_VERSIONS = { original = 1, two = 2, fixedOffsets = 3, current = 3}
-
-
 -- Represents the current styles and images to apply to the game UI
 ---@class Theme
 ---@field path string
@@ -48,7 +44,7 @@ Theme =
   function(self, fullPath, foldername)
     self.path = fullPath
     self.name = foldername
-    self.version = THEME_VERSIONS.original
+    self.version = Theme.THEME_VERSIONS.original
     self.images = {} -- theme images
     self.fontMaps = {}
     self.sounds = {} -- theme sfx
@@ -61,6 +57,9 @@ Theme =
     self.main_menu_max_height = 0
   end
 )
+
+---@enum ThemeVersion
+Theme.THEME_VERSIONS = { original = 1, two = 2, fixedOffsets = 3, current = 3}
 
 Theme.TYPE = "theme"
 -- name of the top level save directory for mods of this type
@@ -723,8 +722,8 @@ function Theme:loadMusic(full)
 end
 
 function Theme:upgradeAndSaveVerboseConfig()
-  if self.version == THEME_VERSIONS.original then
-    self.version = THEME_VERSIONS.two
+  if self.version == Theme.THEME_VERSIONS.original then
+    self.version = Theme.THEME_VERSIONS.two
     self:saveVerboseConfig()
   end
 end
@@ -751,9 +750,9 @@ function Theme.json_init(self)
   -- Then override with custom theme
   local customData = fileUtils.readJsonFile(self.path .. "/config.json")
   local version = self:versionForJSONVersion(customData.version)
-  if version == THEME_VERSIONS.original then
+  if version == Theme.THEME_VERSIONS.original then
     self:loadVersion1DefaultValues()
-  elseif version == THEME_VERSIONS.two then
+  elseif version == Theme.THEME_VERSIONS.two then
     self:loadVersion2DefaultValues()
   end
   self:applyJSONData(customData)
@@ -765,7 +764,7 @@ function Theme:versionForJSONVersion(jsonVersion)
   if jsonVersion and type(jsonVersion) == "number" then
     return  jsonVersion
   else
-    return THEME_VERSIONS.original
+    return Theme.THEME_VERSIONS.original
   end
 end
 
@@ -804,7 +803,7 @@ function Theme:final_init()
 end
 
 function Theme:offsetsAreFixed()
-  return self.version >= THEME_VERSIONS.fixedOffsets
+  return self.version >= Theme.THEME_VERSIONS.fixedOffsets
 end
 
 function Theme:chainImage(chainAmount)

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -24,14 +24,31 @@ local flags = {
   "us" -- United States of America
 }
 
+---@enum ThemeVersion
+local THEME_VERSIONS = { original = 1, two = 2, fixedOffsets = 3, current = 3}
+
+
 -- Represents the current styles and images to apply to the game UI
+---@class Theme
+---@field path string
+---@field name string
+---@field version ThemeVersion
+---@field images table
+---@field fontMaps table
+---@field sounds table<string, (love.Source | table | nil)>
+---@field musics table<string, love.Source>
+---@field font table
+---@field main_menu_screen_pos number[]
+---@field main_menu_y_max number
+---@field main_menu_max_height number
+---@field defaultStage Stage
 Theme =
   class(
+---@param self Theme
   function(self, fullPath, foldername)
-    self.VERSIONS = { original = 1, two = 2, fixedOffsets = 3, current = 3}
     self.path = fullPath
     self.name = foldername
-    self.version = self.VERSIONS.original
+    self.version = THEME_VERSIONS.original
     self.images = {} -- theme images
     self.fontMaps = {}
     self.sounds = {} -- theme sfx
@@ -305,6 +322,25 @@ function Theme:loadMenuGraphics()
   self.images.IMG_bug = self:load_theme_img("bug")
 end
 
+local MAX_SUPPORTED_PLAYERS = 2
+
+---@param theme Theme
+---@return table<integer, table<integer, love.Texture>>
+local function loadGridCursors(theme)
+  local gridCursors = {}
+  theme.images.IMG_char_sel_cursors = {}
+  for player_num = 1, MAX_SUPPORTED_PLAYERS do
+    gridCursors[player_num] = {}
+    for position_num = 1, 2 do
+      gridCursors[player_num][position_num] = theme:load_theme_img("p" .. player_num .. "_select_screen_cursor" .. position_num)
+    end
+  end
+
+  theme.images.IMG_char_sel_cursors = gridCursors
+
+  return theme.images.IMG_char_sel_cursors
+end
+
 function Theme:loadSelectionGraphics()
   self.images.flags = {}
   for _, flag in ipairs(flags) do
@@ -337,16 +373,12 @@ function Theme:loadSelectionGraphics()
   self.images.IMG_random_stage = self:load_theme_img("random_stage")
   self.images.IMG_random_character = self:load_theme_img("random_character")
 
-  local MAX_SUPPORTED_PLAYERS = 2
-  self.images.IMG_char_sel_cursors = {}
   self.images.IMG_players = {}
   for player_num = 1, MAX_SUPPORTED_PLAYERS do
     self.images.IMG_players[player_num] = self:load_theme_img("p" .. player_num)
-    self.images.IMG_char_sel_cursors[player_num] = {}
-    for position_num = 1, 2 do
-      self.images.IMG_char_sel_cursors[player_num][position_num] = self:load_theme_img("p" .. player_num .. "_select_screen_cursor" .. position_num)
-    end
   end
+
+  loadGridCursors(self)
 end
 
 function Theme:loadIngameGraphics()
@@ -594,6 +626,10 @@ function Theme:applyConfigVolume()
   SoundController:applyMusicVolume(self.musics)
 end
 
+
+---@param theme Theme
+---@param SFX_name string
+---@return love.Source?
 local function loadThemeSfx(theme, SFX_name)
   local dirs_to_check = {
     theme.path .. "/sfx/",
@@ -630,12 +666,14 @@ function Theme:loadIngameSfx()
   self.sounds.game_over = loadThemeSfx(self, "gameover")
   self.sounds.countdown = loadThemeSfx(self, "countdown")
   self.sounds.go = loadThemeSfx(self, "go")
+  ---@type love.Source[]
   self.sounds.garbage_thud = {
       loadThemeSfx(self, "thud_1"),
       loadThemeSfx(self, "thud_2"),
       loadThemeSfx(self, "thud_3")
     }
-    self.sounds.pops = {}
+  ---@type love.Source[][]
+  self.sounds.pops = {}
 
   for popLevel = 1, 4 do
     self.sounds.pops[popLevel] = {}
@@ -685,8 +723,8 @@ function Theme:loadMusic(full)
 end
 
 function Theme:upgradeAndSaveVerboseConfig()
-  if self.version == self.VERSIONS.original then
-    self.version = self.VERSIONS.two
+  if self.version == THEME_VERSIONS.original then
+    self.version = THEME_VERSIONS.two
     self:saveVerboseConfig()
   end
 end
@@ -703,7 +741,7 @@ function Theme:saveVerboseConfig()
     jsonData[key] = self[key]
   end
 
-  love.filesystem.write(jsonPath, json.encode(jsonData))
+  fileUtils.writeJson(self.path, "config.json", jsonData)
 end
 
 -- initializes theme using the json settings
@@ -713,9 +751,9 @@ function Theme.json_init(self)
   -- Then override with custom theme
   local customData = fileUtils.readJsonFile(self.path .. "/config.json")
   local version = self:versionForJSONVersion(customData.version)
-  if version == self.VERSIONS.original then
+  if version == THEME_VERSIONS.original then
     self:loadVersion1DefaultValues()
-  elseif version == self.VERSIONS.two then
+  elseif version == THEME_VERSIONS.two then
     self:loadVersion2DefaultValues()
   end
   self:applyJSONData(customData)
@@ -727,7 +765,7 @@ function Theme:versionForJSONVersion(jsonVersion)
   if jsonVersion and type(jsonVersion) == "number" then
     return  jsonVersion
   else
-    return self.VERSIONS.original
+    return THEME_VERSIONS.original
   end
 end
 
@@ -766,7 +804,7 @@ function Theme:final_init()
 end
 
 function Theme:offsetsAreFixed()
-  return self.version >= self.VERSIONS.fixedOffsets
+  return self.version >= THEME_VERSIONS.fixedOffsets
 end
 
 function Theme:chainImage(chainAmount)
@@ -801,10 +839,8 @@ function Theme:loadDefaultStage()
     end
     defaultStage:preload()
     defaultStage:load(true)
-  elseif self.id ~= consts.DEFAULT_THEME_DIRECTORY then
-    defaultStage = themes[consts.DEFAULT_THEME_DIRECTORY]:loadDefaultStage()
   else
-    error("No default stage available")
+    defaultStage = themes[consts.DEFAULT_THEME_DIRECTORY]:loadDefaultStage()
   end
 
   self.defaultStage = defaultStage
@@ -867,6 +903,15 @@ end
 
 function Theme:playMoveSfx()
   SoundController:playSfx(self.sounds.menu_move)
+end
+
+function Theme:getGridCursor(index)
+  index = index or 1
+  if not self.images.IMG_char_sel_cursors or self.images.IMG_char_sel_cursors[index] then
+    loadGridCursors(self)
+  end
+
+  return self.images.IMG_char_sel_cursors[index]
 end
 
 return Theme

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -839,8 +839,10 @@ function Theme:loadDefaultStage()
     end
     defaultStage:preload()
     defaultStage:load(true)
-  else
+  elseif self.path ~= consts.DEFAULT_THEME_DIRECTORY then
     defaultStage = themes[consts.DEFAULT_THEME_DIRECTORY]:loadDefaultStage()
+  else
+    error("No default stage available")
   end
 
   self.defaultStage = defaultStage

--- a/client/src/scenes/CharacterSelect.lua
+++ b/client/src/scenes/CharacterSelect.lua
@@ -446,7 +446,7 @@ function CharacterSelect:createCursor(grid, player)
     startPosition = {x = 9, y = 2},
     player = player,
     -- this needs to be index, not playerNumber, as playerNumber is a server prop
-    frameImages = themes[config.theme].images.IMG_char_sel_cursors[tableUtils.indexOf(GAME.battleRoom.players, player)],
+    frameImages = themes[config.theme]:getGridCursor(tableUtils.indexOf(GAME.battleRoom.players, player)),
   })
 
   player:connectSignal("wantsReadyChanged", cursor, cursor.setRapidBlinking)

--- a/client/src/scenes/ModManagement.lua
+++ b/client/src/scenes/ModManagement.lua
@@ -55,7 +55,7 @@ function ModManagement:load()
   self.cursor = GridCursor({
     grid = self.characterGrid,
     player = GAME.localPlayer,
-    frameImages = themes[config.theme].images.IMG_char_sel_cursors[1],
+    frameImages = themes[config.theme]:getGridCursor(1),
     startPosition = {x = 9, y = 1},
   })
 

--- a/client/src/ui/GridCursor.lua
+++ b/client/src/ui/GridCursor.lua
@@ -19,7 +19,7 @@ local GridCursor = class(function(self, options)
 
   self.player = options.player
   self.player.cursor = self
-  self.frameImages = options.frameImages or themes[config.theme].images.IMG_char_sel_cursors[self.player.playerNumber]
+  self.frameImages = options.frameImages or themes[config.theme]:getGridCursor(self.player.playerNumber)
   self.imageWidth, self.imageHeight = self.frameImages[1]:getDimensions()
   self.quads = {}
   self.quads.left = love.graphics.newQuad(0, 0, self.imageWidth / 2, self.imageHeight, self.imageWidth, self.imageHeight)

--- a/client/tests/ThemeTests.lua
+++ b/client/tests/ThemeTests.lua
@@ -9,7 +9,7 @@ defaultTheme:load()
 
 assert(defaultTheme ~= nil)
 assert(defaultTheme.name ~= nil)
-assert(defaultTheme.version == defaultTheme.VERSIONS.current)
+assert(defaultTheme.version == defaultTheme.THEME_VERSIONS.current)
 assert(defaultTheme.images.bg_main ~= nil)
 assert(defaultTheme.multibar_is_absolute == true)
 assert(defaultTheme.images.IMG_cards[true][0] ~= nil)
@@ -52,7 +52,7 @@ local v1Theme = Theme(Theme.themeDirectoryPath .. "V1Test", "V1Test")
 v1Theme:load()
 assert(v1Theme ~= nil)
 assert(v1Theme.name == "V1Test")
-assert(v1Theme.version == v1Theme.VERSIONS.two) -- it was upgraded
+assert(v1Theme.version == v1Theme.THEME_VERSIONS.two) -- it was upgraded
 assert(v1Theme.images.bg_main ~= nil)
 assert(v1Theme.multibar_is_absolute == false) -- old v1 default
 assert(v1Theme.bg_main_is_tiled == true) -- override from v1 default


### PR DESCRIPTION
Reported by Kiyobi:
```
Error: Please share your crash.log with the developers to get help with this!

Stack Trace: 
    client/src/scenes/ModManagement.lua:58: in function 'load'
    client/src/scenes/ModManagement.lua:21: in function 'init'
    common/lib/class.lua:42: in function 'initializeObject'
    common/lib/class.lua:5: in function 'ModManagement'
    client/src/scenes/OptionsMenu.lua:208: in function 'onClick'
    client/src/ui/Button.lua:29: in function 'onRelease'
    client/src/ui/touchHandler.lua:40: in function 'release'
    main.lua:96: in function <main.lua:94>
    client/src/CustomRun.lua:95: in function 'processEvents'
    client/src/CustomRun.lua:105: in function 'runInternal'
    client/src/CustomRun.lua:210: in function <client/src/CustomRun.lua:208>
    [C]: in function 'xpcall'
Username: KiyobiFujisaki
Theme: Panel Attack Modern
Error Message: client/src/scenes/ModManagement.lua:58: attempt to index field 'IMG_char_sel_cursors' (a nil value)
Engine Version: 048
Build Version: stable 1737613101
Operating System: OS: Windows
Love Version: 12.0.0
Renderer Info: OpenGL;4.3.0 NVIDIA 560.94;NVIDIA Corporation;NVIDIA GeForce RTX 4070/PCIe/SSE2
UTC Time: 2025-01-31 03:46:07
Scene: OptionsMenu
```

To allow for relatively quick scrolling through themes, only a small subset of theme assets is loaded when going through themes and the full theme reload happens when returning to the main menu.
As the mod management needs the grid cursor, it crashed after the theme was changed because the asset had not been reloaded.

Rather than adding it to the list of assets that get reloaded immediately, I added a new function `Theme:getGridCursor(index)`. I think going forward we should try to encapsulate access to theme assets so that other code does not depend on theme internals and themes can load their needed assets ad hoc where needed.