### PR TITLE
Fix Online Player Number being swapped sometimes

### DIFF
--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -283,6 +283,16 @@ function BattleRoom:addPlayer(player)
   end
   self.players[#self.players + 1] = player
 
+  -- make sure the local player ends up as P1 (left side)
+  -- if both are local or both are not, order by playerNumber
+  table.sort(self.players, function(a, b)
+    if a.isLocal == b.isLocal then
+      return a.playerNumber < b.playerNumber
+    else
+      return a.isLocal
+    end
+  end)
+
   if player.isLocal then
     self:connectSignal("allAssetsLoadedChanged", player, player.setLoaded)
   end

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -36,6 +36,7 @@ local ChallengeModePlayerStack = require("client.src.ChallengeModePlayerStack")
 ---@field spectatorString string newLine concatenated version of spectators for display
 ---@field winners MatchParticipant[]
 
+--- The ClientMatch is a way to create a match that will run with graphics and sounds on a client.
 ---@class ClientMatch : Signal
 ---@overload fun(players: MatchParticipant[], doCountdown: boolean, stackInteraction: integer, winConditions: integer[], gameOverConditions: integer[], supportsPause: boolean, optionalArgs: table?): ClientMatch
 local ClientMatch = class(
@@ -63,8 +64,7 @@ function(self, players, doCountdown, stackInteraction, winConditions, gameOverCo
     self.ranked = optionalArgs.ranked
   end
 
-  -- match needs its own table so it can sort players with impunity
-  self.players = shallowcpy(players)
+  self.players = players
 
   self.currentMusicIsDanger = false
 
@@ -132,17 +132,6 @@ function ClientMatch:runGameOver()
 end
 
 function ClientMatch:start()
-  -- battle room may add the players in any order
-  -- match has to make sure the local player ends up as P1 (left side)
-  -- if both are local or both are not, order by playerNumber
-  table.sort(self.players, function(a, b)
-    if a.isLocal == b.isLocal then
-      return a.playerNumber < b.playerNumber
-    else
-      return a.isLocal
-    end
-  end)
-
   self.stacks = {}
   local engineStacks = {}
   for i, player in ipairs(self.players) do


### PR DESCRIPTION
The drawing of "Player 1" is just done based on the player order in the table.

Lets just sort earlier so it is right for the character select screen

Fixes issue #586