### PR TITLE
Fix Bool Selector for mods, plus graphics update

### DIFF
--- a/client/src/scenes/CharacterSelect.lua
+++ b/client/src/scenes/CharacterSelect.lua
@@ -602,20 +602,6 @@ function CharacterSelect:createRankedSelection(player, width)
 
   Focusable(rankedSelector)
 
-  rankedSelector.receiveInputs = function(self, inputs)
-    if inputs.isDown["Up"] then
-      self:setValue(true)
-    elseif inputs.isDown["Down"] then
-      self:setValue(false)
-    elseif inputs.isDown["Swap1"] then
-      GAME.theme:playValidationSfx()
-      self:yieldFocus()
-    elseif inputs.isDown["Swap2"] then
-      GAME.theme:playCancelSfx()
-      self:yieldFocus()
-    end
-  end
-
   player:connectSignal("wantsRankedChanged", rankedSelector, rankedSelector.setValue)
 
   -- player number icon
@@ -624,7 +610,7 @@ function CharacterSelect:createRankedSelection(player, width)
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
     vAlign = "center",
-    x = 4,
+    x = 0,
     scale = 2,
   })
   rankedSelector.playerNumberIcon = playerNumberIcon
@@ -646,20 +632,6 @@ function CharacterSelect:createStyleSelection(player, width)
   -- as likely the UI needs to be altered to accomodate the style choice
 
   Focusable(styleSelector)
-
-  styleSelector.receiveInputs = function(self, inputs)
-    if inputs.isDown["Up"] then
-      self:setValue(true)
-    elseif inputs.isDown["Down"] then
-      self:setValue(false)
-    elseif inputs.isDown["Swap1"] then
-      GAME.theme:playValidationSfx()
-      self:yieldFocus()
-    elseif inputs.isDown["Swap2"] then
-      GAME.theme:playCancelSfx()
-      self:yieldFocus()
-    end
-  end
 
   player:connectSignal("styleChanged", styleSelector, function(p, style)
       if style == GameModes.Styles.MODERN then

--- a/client/src/scenes/CharacterSelect.lua
+++ b/client/src/scenes/CharacterSelect.lua
@@ -610,7 +610,7 @@ function CharacterSelect:createRankedSelection(player, width)
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
     vAlign = "center",
-    x = 0,
+    x = 2,
     scale = 2,
   })
   rankedSelector.playerNumberIcon = playerNumberIcon
@@ -648,7 +648,7 @@ function CharacterSelect:createStyleSelection(player, width)
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
     vAlign = "center",
-    x = 4,
+    x = 8,
     scale = 2,
   })
   styleSelector.playerNumberIcon = playerNumberIcon

--- a/client/src/scenes/CharacterSelect2p.lua
+++ b/client/src/scenes/CharacterSelect2p.lua
@@ -39,10 +39,7 @@ function CharacterSelect2p:loadUserInterface()
 
   self.ui.leaveButton = self:createLeaveButton()
   self.ui.rankedSelection = MultiPlayerSelectionWrapper({vFill = true, alignment = "left", hAlign = "center", vAlign = "center"})
-  local trueLabel = Label({text = "ss_ranked", vAlign = "top", hAlign = "center"})
-  local falseLabel = Label({text = "ss_casual", vAlign = "bottom", hAlign = "center"})
-  self.ui.rankedSelection:addChild(trueLabel)
-  self.ui.rankedSelection:addChild(falseLabel)
+  self.ui.rankedSelection:setTitle("ss_ranked")
 
   local levelHeight
   local panelHeight = (self.ui.grid.unitSize - self.ui.grid.unitMargin * 2) / #GAME.battleRoom.players - self.ui.panelSelection.height
@@ -50,18 +47,18 @@ function CharacterSelect2p:loadUserInterface()
   local rankedWidth
 
   if GAME.battleRoom.online then
-    self.ui.grid:createElementAt(1, 2, 2, 1, "panelSelection", self.ui.panelSelection)
+    self.ui.grid:createElementAt(1, 2, 2, 1, "panelSelection", self.ui.panelSelection, nil, true)
     self.ui.grid:createElementAt(3, 2, 2, 1, "rankedSelection", self.ui.rankedSelection, nil, true)
-    self.ui.grid:createElementAt(5, 2, 2, 1, "stageSelection", self.ui.stageSelection)
-    self.ui.grid:createElementAt(7, 2, 2, 1, "levelSelection", self.ui.levelSelection)
+    self.ui.grid:createElementAt(5, 2, 2, 1, "stageSelection", self.ui.stageSelection, nil, true)
+    self.ui.grid:createElementAt(7, 2, 2, 1, "levelSelection", self.ui.levelSelection, nil, true)
 
     levelHeight = 12
     stageWidth = self.ui.grid.unitSize - self.ui.grid.unitMargin * 2
     rankedWidth = stageWidth
   else
-    self.ui.grid:createElementAt(1, 2, 2, 1, "panelSelection", self.ui.panelSelection)
-    self.ui.grid:createElementAt(3, 2, 3, 1, "stageSelection", self.ui.stageSelection)
-    self.ui.grid:createElementAt(6, 2, 3, 1, "levelSelection", self.ui.levelSelection)
+    self.ui.grid:createElementAt(1, 2, 2, 1, "panelSelection", self.ui.panelSelection, nil, true)
+    self.ui.grid:createElementAt(3, 2, 3, 1, "stageSelection", self.ui.stageSelection, nil, true)
+    self.ui.grid:createElementAt(6, 2, 3, 1, "levelSelection", self.ui.levelSelection, nil, true)
 
     levelHeight = 20
     stageWidth = self.ui.grid.unitSize * 1.5 - self.ui.grid.unitMargin * 2

--- a/client/src/scenes/EndlessMenu.lua
+++ b/client/src/scenes/EndlessMenu.lua
@@ -51,10 +51,7 @@ function EndlessMenu:loadUserInterface()
   self.ui.grid:createElementAt(3, 2, 2, 1, "stageSelection", self.ui.stageSelection, nil, true)
 
   self.ui.styleSelection = MultiPlayerSelectionWrapper({vFill = true, alignment = "left", hAlign = "center", vAlign = "center"})
-  local trueLabel = Label({text = "endless_modern", vAlign = "top", hAlign = "center"})
-  local falseLabel = Label({text = "endless_classic", vAlign = "bottom", hAlign = "center"})
-  self.ui.styleSelection:addChild(trueLabel)
-  self.ui.styleSelection:addChild(falseLabel)
+  self.ui.styleSelection:setTitle("endless_modern")
   local styleSelector = self:createStyleSelection(player, unitSize)
   self.ui.styleSelection:addElement(styleSelector, player)
 

--- a/client/src/scenes/EndlessMenu.lua
+++ b/client/src/scenes/EndlessMenu.lua
@@ -6,7 +6,7 @@ local MultiPlayerSelectionWrapper = require("client.src.ui.MultiPlayerSelectionW
 local Label = require("client.src.ui.Label")
 local Stepper = require("client.src.ui.Stepper")
 local Slider = require("client.src.ui.Slider")
-local canBeFocused = require("client.src.ui.Focusable")
+local Focusable = require("client.src.ui.Focusable")
 
 -- Scene for the endless game setup menu
 local EndlessMenu = class(

--- a/client/src/scenes/ModManagement.lua
+++ b/client/src/scenes/ModManagement.lua
@@ -164,26 +164,21 @@ function ModManagement:loadStageGrid()
       local stage = allStages[stageId]
       local icon = ImageContainer({drawBorders = true, image = stage.images.thumbnail, hFill = true, vFill = true, hAlign = "center", vAlign = "center"})
       local enableSelector = BoolSelector({startValue = not not stages[stage.id], hAlign = "center", vAlign = "center", hFill = true, vFill = true})
-      enableSelector.onSelect = function(self, cursor)
-        if inputs.isDown["Swap1"] then
-          self:setValue(not self.value)
-          stage:enable(self.value)
-          if tableUtils.length(visibleStages) == 0 then
-            SoundController:stopSfx(GAME.theme.sounds.menu_validate)
-            GAME.theme:playCancelSfx()
-            self:setValue(not self.value)
-            stage:enable(self.value)
-          end
-          if not self.value and stage.id == config.stage and #visibleStages > 0 then
-            GAME.localPlayer:setStage(stages[consts.RANDOM_STAGE_SPECIAL_VALUE])
-          end
+      enableSelector.onValueChange = function(boolSelector, value)
+        GAME.theme:playValidationSfx()
+        stage:enable(boolSelector.value)
+        if tableUtils.length(visibleStages) == 0 then
+          SoundController:stopSfx(GAME.theme.sounds.menu_validate)
+          GAME.theme:playCancelSfx()
+          boolSelector:setValue(not boolSelector.value)
+          stage:enable(boolSelector.value)
+        end
+        if not boolSelector.value and stage.id == config.stage and #visibleStages > 0 then
+          GAME.localPlayer:setStage(stages[consts.RANDOM_STAGE_SPECIAL_VALUE])
         end
       end
       local visibilitySelector = BoolSelector({startValue = stage.isVisible, hAlign = "center", vAlign = "center", hFill = true, vFill = true})
-      visibilitySelector.onSelect = function(self, cursor)
-        if inputs.isDown["Swap1"] then
-          self:setValue(not self.value)
-        end
+      visibilitySelector.onValueChange = function(boolSelector, value)
       end
       local name = Label({text = stage.display_name, translate = false, hAlign = "center", vAlign = "center"})
       local hasMusicLabel = Label({text = tostring(stage.hasMusic):upper(), translate = false, hAlign = "center", vAlign = "center"})
@@ -243,26 +238,21 @@ function ModManagement:loadCharacterGrid()
       local character = allCharacters[characterId]
       local icon = ImageContainer({drawBorders = true, image = character.images.icon, hFill = true, vFill = true})
       local enableSelector = BoolSelector({startValue = not not characters[character.id], hAlign = "center", vAlign = "center", hFill = true, vFill = true})
-      enableSelector.onSelect = function(self, cursor)
-        if inputs.isDown["Swap1"] then
-          self:setValue(not self.value)
-          character:enable(self.value)
-          if tableUtils.length(visibleCharacters) == 0 then
-            SoundController:stopSfx(GAME.theme.sounds.menu_validate)
-            GAME.theme:playCancelSfx()
-            self:setValue(not self.value)
-            character:enable(self.value)
-          end
-          if not self.value and character.id == config.character and #visibleCharacters > 0 then
-            GAME.localPlayer:setCharacter(characters[consts.RANDOM_CHARACTER_SPECIAL_VALUE])
-          end
+      enableSelector.onValueChange = function(boolSelector, value)
+        GAME.theme:playValidationSfx()
+        character:enable(boolSelector.value)
+        if tableUtils.length(visibleCharacters) == 0 then
+          SoundController:stopSfx(GAME.theme.sounds.menu_validate)
+          GAME.theme:playCancelSfx()
+          boolSelector:setValue(not boolSelector.value)
+          character:enable(boolSelector.value)
+        end
+        if not boolSelector.value and character.id == config.character and #visibleCharacters > 0 then
+          GAME.localPlayer:setCharacter(characters[consts.RANDOM_CHARACTER_SPECIAL_VALUE])
         end
       end
       local visibilitySelector = BoolSelector({startValue = character.isVisible, hAlign = "center", vAlign = "center", hFill = true, vFill = true})
-      visibilitySelector.onSelect = function(self, cursor)
-        if inputs.isDown["Swap1"] then
-          self:setValue(not self.value)
-        end
+      visibilitySelector.onValueChange = function(boolSelector, value)
       end
       local displayName = Label({text = character.display_name, translate = false, hAlign = "center", vAlign = "center"})
       local hasMusicLabel = Label({text = tostring(character.hasMusic):upper(), translate = false, hAlign = "center", vAlign = "center"})

--- a/client/src/scenes/TimeAttackMenu.lua
+++ b/client/src/scenes/TimeAttackMenu.lua
@@ -48,10 +48,7 @@ function TimeAttackMenu:loadUserInterface()
   self.ui.grid:createElementAt(3, 2, 2, 1, "stageSelection", self.ui.stageSelection, nil, true)
 
   self.ui.styleSelection = MultiPlayerSelectionWrapper({vFill = true, alignment = "left", hAlign = "center", vAlign = "center"})
-  local trueLabel = Label({text = "endless_modern", vAlign = "top", hAlign = "center"})
-  local falseLabel = Label({text = "endless_classic", vAlign = "bottom", hAlign = "center"})
-  self.ui.styleSelection:addChild(trueLabel)
-  self.ui.styleSelection:addChild(falseLabel)
+  self.ui.styleSelection:setTitle("endless_modern")
   local styleSelector = self:createStyleSelection(player, unitSize)
   self.ui.styleSelection:addElement(styleSelector, player)
 

--- a/client/src/ui/BoolSelector.lua
+++ b/client/src/ui/BoolSelector.lua
@@ -92,14 +92,13 @@ function BoolSelector:drawSelf()
   GraphicsUtil.applyAlignment(self, fakeCenteredChild)
   love.graphics.translate(self.x, self.y)
 
-  GraphicsUtil.drawRectangle("line", 0, 0, totalWidth, totalLength, nil, nil, nil, nil, circleRadius, circleRadius)
-
   if self.value then
     GraphicsUtil.setColor(30/255, 190/255, 67/255, 1)
     GraphicsUtil.drawRectangle("fill", 0, 0, totalWidth, totalLength, nil, nil, nil, nil, circleRadius, circleRadius)
     GraphicsUtil.setColor(1, 1, 1, 1)
   end
 
+  GraphicsUtil.drawRectangle("line", 0, 0, totalWidth, totalLength, nil, nil, nil, nil, circleRadius, circleRadius)
   love.graphics.circle("fill", circleX, circleY, circleRadius)
 
   GraphicsUtil.resetAlignment()

--- a/client/src/ui/BoolSelector.lua
+++ b/client/src/ui/BoolSelector.lua
@@ -2,14 +2,47 @@ local UiElement = require("client.src.ui.UIElement")
 local class = require("common.lib.class")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 
+--- A BoolSelector is a UIElement that shows if a setting is on or off and lets you toggle it.
 local BoolSelector = class(function(boolSelector, options)
   boolSelector.value = options.startValue or false
   boolSelector.TYPE = "BoolSelector"
+  boolSelector.vertical = false
 end,
 UiElement)
 
+function BoolSelector:onTouch(x, y)
+end
+
 function BoolSelector:onRelease(x, y)
   self:setValue(not self.value)
+end
+
+
+function BoolSelector:onSelect(boolSelector, selector)
+  self:setValue(not self.value)
+end
+
+function BoolSelector:receiveInputs(input)
+  if self.isFocusable then
+    if (input:isPressedWithRepeat("Right") and self.vertical == false) or
+        (input:isPressedWithRepeat("Up") and self.vertical) then
+        self:setValue(true)
+    elseif (input:isPressedWithRepeat("Left") and self.vertical == false) or
+    (input:isPressedWithRepeat("Down") and self.vertical) then
+      self:setValue(false)
+    elseif input.isDown["Swap1"] then
+      GAME.theme:playValidationSfx()
+      self:yieldFocus()
+    elseif input.isDown["Swap2"] then
+      GAME.theme:playCancelSfx()
+      self:yieldFocus()
+    end
+  else 
+    if input.isDown["Swap1"] then
+      GAME.theme:playValidationSfx()
+      self:setValue(not self.value)
+    end
+  end
 end
 
 function BoolSelector:setValue(value)
@@ -23,7 +56,11 @@ end
 -- other code may implement a callback here
 -- function BoolSelector.onValueChange() end
 
-local fakeCenteredChild = {hAlign = "center", vAlign = "center", width = 30, height = 40}
+local circleRadius = 10
+local extraDistance = 16
+local lengthPadding = 2
+local widthPadding = 2
+local fakeCenteredChild = {hAlign = "center", vAlign = "center", width = totalWidth, height = totalLength}
 
 function BoolSelector:drawSelf()
   if DEBUG_ENABLED then
@@ -32,17 +69,38 @@ function BoolSelector:drawSelf()
     GraphicsUtil.setColor(1, 1, 1, 1)
   end
 
+  local circleX = circleRadius + widthPadding
+  local circleY = circleRadius + lengthPadding
+  local totalWidth = circleRadius * 2 + 2 * widthPadding
+  local totalLength = circleRadius * 2 + 2 * lengthPadding
+  if self.vertical then
+    totalLength = totalLength + extraDistance
+    if self.value == false then
+      circleY = circleY + extraDistance
+    end
+  else
+    totalWidth = totalWidth + extraDistance
+    if self.value then
+      circleX = circleX + extraDistance
+    end
+  end
+  fakeCenteredChild.width = totalWidth
+  fakeCenteredChild.height = totalLength
+
   -- we want these to be centered but creating a Rectangle / Circle ui element is maybe a bit too much?
   -- so just apply the translation via a fake element with all necessary props
   GraphicsUtil.applyAlignment(self, fakeCenteredChild)
   love.graphics.translate(self.x, self.y)
 
-  GraphicsUtil.drawRectangle("line", 0, 0, 30, 40, nil, nil, nil, nil, 10, 15)
+  GraphicsUtil.drawRectangle("line", 0, 0, totalWidth, totalLength, nil, nil, nil, nil, circleRadius, circleRadius)
+
   if self.value then
-    love.graphics.circle("fill", 15, 15, 10)
-  else
-    love.graphics.circle("fill", 15, 25, 10)
+    GraphicsUtil.setColor(30/255, 190/255, 67/255, 1)
+    GraphicsUtil.drawRectangle("fill", 0, 0, totalWidth, totalLength, nil, nil, nil, nil, circleRadius, circleRadius)
+    GraphicsUtil.setColor(1, 1, 1, 1)
   end
+
+  love.graphics.circle("fill", circleX, circleY, circleRadius)
 
   GraphicsUtil.resetAlignment()
 end

--- a/client/src/ui/Carousel.lua
+++ b/client/src/ui/Carousel.lua
@@ -1,7 +1,7 @@
 local class = require("common.lib.class")
 local UiElement = require("client.src.ui.UIElement")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
-local canBeFocused = require("client.src.ui.Focusable")
+local Focusable = require("client.src.ui.Focusable")
 local tableUtils = require("common.lib.tableUtils")
 
 local function calculateFontSize(height)
@@ -11,7 +11,7 @@ end
 -- A carousel with arrow touch buttons that allows to spin a selection of elements around in both directions
 -- This is an "abstract" class, classes should inherit this and overwrite createPassenger and drawPassenger
 local Carousel = class(function(carousel, options)
-  canBeFocused(carousel)
+  Focusable(carousel)
 
   if options.passengers == nil then
     carousel.passengers = {}

--- a/client/src/ui/Focusable.lua
+++ b/client/src/ui/Focusable.lua
@@ -1,6 +1,6 @@
 -- use in tandem with FocusDirector.lua
 
-local function canBeFocused(uiElement)
+local function focusable(uiElement)
   uiElement.isFocusable = true
   uiElement.hasFocus = false
   if uiElement.receiveInputs == nil then
@@ -17,4 +17,4 @@ local function canBeFocused(uiElement)
   -- end
 end
 
-return canBeFocused
+return focusable

--- a/client/src/ui/Leaderboard.lua
+++ b/client/src/ui/Leaderboard.lua
@@ -1,7 +1,7 @@
 local class = require("common.lib.class")
 local UiElement = require("client.src.ui.UIElement")
 local Label = require("client.src.ui.Label")
-local canBeFocused = require("client.src.ui.Focusable")
+local Focusable = require("client.src.ui.Focusable")
 local util = require("common.lib.util")
 
 local Leaderboard = class(function(self, options)
@@ -18,7 +18,7 @@ local Leaderboard = class(function(self, options)
   self.firstVisibleIndex = nil
   self.lastVisibleIndex = nil
 
-  canBeFocused(self)
+  Focusable(self)
 end,
 UiElement)
 

--- a/client/src/ui/MultiPlayerSelectionWrapper.lua
+++ b/client/src/ui/MultiPlayerSelectionWrapper.lua
@@ -1,12 +1,13 @@
 local StackPanel = require("client.src.ui.StackPanel")
 local Label = require("client.src.ui.Label")
 local class = require("common.lib.class")
-local focusable = require("client.src.ui.Focusable")
+local Focusable = require("client.src.ui.Focusable")
 
 -- forms a layer of abstraction between a player specific selector (e.g. GridCursor) and UiElements that exist per player
 -- the MultiPlayerSelectionWrapper displays the UiElements of all players but upon selection only redirects inputs to the 
+-- player that owns the input method
 local MultiPlayerSelectionWrapper = class(function(wrapper, options)
-  focusable(wrapper)
+  Focusable(wrapper)
   wrapper.activeElement = nil
   wrapper.wrappedElements = {}
 


### PR DESCRIPTION
Fixes #597 so the selector works for both touch and buttons
Also removed duplicate code for focusable selectors by moving into BoolSelector class
Also fixed the BoolSelector graphics to make it more obvious when it is on and able to be horizontal
Used a horizontal version everywhere for now as its more standard.
Made the ranked selector have a title rather than the up down titles as that was confusing and its more obvious now.
Standarization of the focusable require name, maybe it should be named "makeFocusable"?
Fixed 2p only having border on ranked