### PR TITLE
Limit amount of logs kept in memory

### DIFF
--- a/client/src/server_queue.lua
+++ b/client/src/server_queue.lua
@@ -49,10 +49,7 @@ end
 -- push a server message in queue
 function ServerQueue.push(self, msg)
   if not msg[NetworkProtocol.serverMessageTypes.opponentInput.prefix] and not msg[NetworkProtocol.serverMessageTypes.secondOpponentInput.prefix] then
-    local t = table_to_string(msg)
-    if not msg.replay_of_match_so_far then
-      logger.debug("message received:\n" .. table_to_string(msg))
-    end
+    logger.debug("message received:\n" .. table_to_string(msg))
   end
   local last = self.last + 1
   self.last = last

--- a/common/engine/Match.lua
+++ b/common/engine/Match.lua
@@ -294,7 +294,7 @@ function Match:pushGarbageTo(stack)
       end
       local garbageDelivery = st:getReadyGarbageAt(stack.clock)
       if garbageDelivery then
-        logger.debug("Pushing garbage delivery to incoming garbage queue: " .. table_to_string(garbageDelivery))
+        --logger.debug("Pushing garbage delivery to incoming garbage queue: " .. table_to_string(garbageDelivery))
         stack:receiveGarbage(garbageDelivery)
       end
     end

--- a/common/lib/Ring.lua
+++ b/common/lib/Ring.lua
@@ -1,0 +1,35 @@
+local class = require("common.lib.class")
+
+--- A simple class for limiting the amount of memory taken up by transient data (e.g. logs)
+---@class Ring
+---@field size integer
+---@field currentIndex integer
+---@field content any[]
+local Ring = class(
+function(self, size)
+  self.size = size
+  self.currentIndex = 1
+  self.content = table.new(size, 0)
+end)
+
+function Ring:push(item)
+  self.content[self.currentIndex] = item
+
+  self.currentIndex = self.currentIndex + 1
+
+  if self.currentIndex > self.size then
+    self.currentIndex = 1
+  end
+end
+
+function Ring:__tostring()
+  local t = {}
+  for i = self.currentIndex + 1, self.currentIndex + self.size do
+    local index = wrap(1, i, self.size)
+    t[#t+1] = tostring(self.content[index])
+  end
+
+  return table.concat(t)
+end
+
+return Ring

--- a/common/lib/Ring.lua
+++ b/common/lib/Ring.lua
@@ -1,4 +1,5 @@
 local class = require("common.lib.class")
+table.new = require("table.new")
 
 --- A simple class for limiting the amount of memory taken up by transient data (e.g. logs)
 ---@class Ring
@@ -26,10 +27,12 @@ function Ring:__tostring()
   local t = {}
   for i = self.currentIndex + 1, self.currentIndex + self.size do
     local index = wrap(1, i, self.size)
-    t[#t+1] = tostring(self.content[index])
+    if self.content[index] then
+      t[#t+1] = tostring(self.content[index])
+    end
   end
 
-  return table.concat(t)
+  return table.concat(t, "\n")
 end
 
 return Ring

--- a/common/lib/RingBuffer.lua
+++ b/common/lib/RingBuffer.lua
@@ -2,18 +2,18 @@ local class = require("common.lib.class")
 table.new = require("table.new")
 
 --- A simple class for limiting the amount of memory taken up by transient data (e.g. logs)
----@class Ring
+---@class RingBuffer
 ---@field size integer
 ---@field currentIndex integer
 ---@field content any[]
-local Ring = class(
+local RingBuffer = class(
 function(self, size)
   self.size = size
   self.currentIndex = 1
   self.content = table.new(size, 0)
 end)
 
-function Ring:push(item)
+function RingBuffer:push(item)
   self.content[self.currentIndex] = item
 
   self.currentIndex = self.currentIndex + 1
@@ -23,7 +23,7 @@ function Ring:push(item)
   end
 end
 
-function Ring:__tostring()
+function RingBuffer:__tostring()
   local t = {}
   for i = self.currentIndex + 1, self.currentIndex + self.size do
     local index = wrap(1, i, self.size)
@@ -35,4 +35,4 @@ function Ring:__tostring()
   return table.concat(t, "\n")
 end
 
-return Ring
+return RingBuffer

--- a/common/lib/logger.lua
+++ b/common/lib/logger.lua
@@ -1,5 +1,5 @@
 local os = require("os")
-local Ring = require("common.lib.Ring")
+local RingBuffer = require("common.lib.RingBuffer")
 local socket
 if love then
   -- love comes with luasocket
@@ -11,7 +11,7 @@ else
 end
 
 local logger = {
-  messageBuffer = Ring(2048)
+  messageBuffer = RingBuffer(2048)
 }
 
 local TRACE = 0 -- Log something that is very detailed verbose debug logging

--- a/common/lib/logger.lua
+++ b/common/lib/logger.lua
@@ -1,4 +1,5 @@
 local os = require("os")
+local Ring = require("common.lib.Ring")
 local socket
 if love then
   -- love comes with luasocket
@@ -10,7 +11,7 @@ else
 end
 
 local logger = {
-  messages = {}
+  messageBuffer = Ring(2048)
 }
 
 local TRACE = 0 -- Log something that is very detailed verbose debug logging
@@ -63,13 +64,13 @@ function direct_log(prefix, msg)
   -- %x - Date
   -- %X - Time
   local message = string.format("%s.%03d %s:%s", os.date("%x %X"), socket_millis, prefix, msg)
-  if not SERVER_MODE then
-    logger.messages[#logger.messages+1] = message
-  end
   print(message)
-  -- note the space in the string below is on purpose
-  if SERVER_MODE == nil and (prefix == "ERROR" or prefix == " WARN") then
-    love.filesystem.append("warnings.txt", message .. "\n")
+  if not SERVER_MODE then
+    logger.messageBuffer:push(message)
+    -- the space in the string below is on purpose
+    if prefix == "ERROR" or prefix == " WARN" then
+      love.filesystem.append("warnings.txt", message .. "\n")
+    end
   end
 end
 

--- a/main.lua
+++ b/main.lua
@@ -145,7 +145,7 @@ function love.quit()
   end
 
   write_conf_file()
-  pcall(love.filesystem.write, "debug.log", table.concat(logger.messages, "\n"))
+  pcall(love.filesystem.write, "debug.log", tostring(logger.messageBuffer))
 
   if GAME.updater then
     while GAME.updater.state ~= GAME_UPDATER_STATES.idle do
@@ -156,7 +156,7 @@ end
 
 function love.errorhandler(msg)
   if lldebugger then
-    pcall(love.filesystem.write, "debug.log", table.concat(logger.messages, "\n"))
+    pcall(love.filesystem.write, "debug.log", tostring(logger.messageBuffer))
     error(msg, 2)
   end
 
@@ -219,9 +219,9 @@ function love.errorhandler(msg)
     table.insert(errorLines, sanitizedMessage)
     logger.info(sanitizedMessage)
   end
-  if logger.messages then
+  if logger.messageBuffer then
     logger.info("config during crash: " .. table_to_string(config))
-    pcall(love.filesystem.write, "crash.log", table.concat(logger.messages, "\n"))
+    pcall(love.filesystem.write, "crash.log", tostring(logger.messageBuffer))
   end
   if #sanitizedMessage ~= #msg then
     table.insert(errorLines, "Invalid UTF-8 string in error message.")

--- a/testLauncher.lua
+++ b/testLauncher.lua
@@ -82,13 +82,13 @@ function love.draw()
 end
 
 function love.quit()
-  love.filesystem.write("test.log", table.concat(logger.messages, "\n"))
+  love.filesystem.write("test.log", tostring(logger.messageBuffer))
 end
 
 local love_errorhandler = love.errorhandler
 function love.errorhandler(msg)
   logger.info(msg)
-  pcall(love.filesystem.write, "test-crash.log", table.concat(logger.messages, "\n"))
+  pcall(love.filesystem.write, "test-crash.log", tostring(logger.messageBuffer))
   if lldebugger then
     error(msg, 2)
   else


### PR DESCRIPTION
closes #601 

This is a very naive implementation of a RingBuffer not doing any more than necessary to solve the issue with logs taking up increasing amounts of memory.

Also reducing some logging overhead in gameplay when pushing garbage as these were usually bigger tables that are not interesting when not debugging engine issues.