### PR TITLE
Improve replay+rollback performance

### DIFF
--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -826,9 +826,6 @@ function PlayerStack:drawDebug()
     GraphicsUtil.printf("Confirmed " .. #engine.confirmedInput, drawX, drawY)
 
     drawY = drawY + padding
-    GraphicsUtil.printf("input_buffer " .. #engine.input_buffer, drawX, drawY)
-
-    drawY = drawY + padding
     GraphicsUtil.printf("rollbackCount " .. engine.rollbackCount, drawX, drawY)
 
     drawY = drawY + padding

--- a/client/src/network/PlayerStack.lua
+++ b/client/src/network/PlayerStack.lua
@@ -25,7 +25,6 @@ function PlayerStack:send_controls()
     -- Send 1 frame at clock time 0 then wait till we get our first input from the other player.
     -- This will cause a player that got the start message earlier than the other player to wait for the other player just once.
     -- print("self.confirmedInput="..(self.confirmedInput or "nil"))
-    -- print("self.input_buffer="..(self.input_buffer or "nil"))
     -- print("send_controls returned immediately")
     return
   end

--- a/common/engine/Match.lua
+++ b/common/engine/Match.lua
@@ -265,7 +265,7 @@ function Match:run()
   -- for i = 1, #self.players do
   --   local stack = self.players[i].stack
   --   if stack and stack.is_local not stack:game_ended() then
-  --     assert(#stack.input_buffer == 0, "Local games should always simulate all inputs")
+  --     assert(#stack.confirmedInput == stack.clock, "Local games should always simulate all inputs")
   --   end
   -- end
 

--- a/common/engine/Panel.lua
+++ b/common/engine/Panel.lua
@@ -18,9 +18,8 @@ require("common.lib.util")
 ---@field chaining boolean? if the panel will cause a chain when matched in this moment
 ---@field propagatesChaining boolean panels are updated bottom to top
 --- panels will check if this is set on the panel below to update their chaining state in combination with their own state
----@field matchAnyway boolean a flag to determine if a hovering panel can be matched or not despite hovering panels normally being unmatchable
---- PA always checks matches and then updates everything at once; the flag exists to compensate for the order of actions to keep some hovering panels matchable on their first frame
---- if we first updated swapping panels, then checked matches and then updated all panels it might be possible to get rid of this flag; debatable if that is desirable
+---@field debug_tag string? Non-functional field, may be set for debugging purposes
+-- GARBAGE-EXCLUSIVE PROPERTIES
 ---@field isGarbage boolean? if the panel is acting as garbage
 ---@field garbageId integer? the unique id of the piece of garbage the panel belongs to (unique per stack)
 ---@field metal boolean? if the panel is acting as shock garbage
@@ -33,9 +32,9 @@ require("common.lib.util")
 ---@field pop_index integer? index of the panel in the sequence formed of all garbage panels in the match scheduled to be garbage popping
 ---@field shake_time integer? how many frames of invincibility the garbage panel grants upon making contact with non-garbage panels on the screen for the first time
 --- all panels in a garbage block have the same shake_time
+-- NON-GARBAGE EXCLUSIVE PROPERTIES
 ---@field combo_size integer? size of the regular match the panel is part of; size compared against index determines the pop timing; also used for determining popFX size
 ---@field combo_index integer? pop index among panels in the regular match; index compared against size determines the pop timing
----@field chain_index integer? number of the chain link if this panel got matched as part of a chain (I think)
 ---@field isSwappingFromLeft boolean? a direction indicator so we can check if swaps are possible with currently swapping panels and their surroundings
 ---@field dont_swap boolean? if a panel is not supposed to be swappable for arcane reasons it gets flagged down with this
 --- in the future this should probably get axed
@@ -45,7 +44,9 @@ require("common.lib.util")
 --- then this panel should be forced to hover after and the panels above as well
 --- indicated by this bool for itself and the panels above
 ---@field fell_from_garbage integer? Animation timer for "bounce" after falling from garbage.
----@field debug_tag string? Non-functional field, may be set for debugging purposes
+---@field matchAnyway boolean a flag to determine if a hovering panel can be matched or not despite hovering panels normally being unmatchable
+--- PA always checks matches and then updates everything at once; the flag exists to compensate for the order of actions to keep some hovering panels matchable on their first frame
+--- if we first updated swapping panels, then checked matches and then updated all panels it might be possible to get rid of this flag; debatable if that is desirable
 
 -- clears information relating to state, matches and various stuff
 -- a true argument must be supplied to clear the chaining flag as well
@@ -63,9 +64,6 @@ local function clear_flags(panel, clearChaining)
   -- size compared against index determines the pop timing
   -- also used for determining popFX size
   panel.combo_size = nil
-
-  -- number of the chain link if this panel got matched as part of a chain (I think)
-  panel.chain_index = nil
 
   -- a direction indicator so we can check if swaps are possible with currently swapping panels
   -- ...and their surroundings

--- a/common/engine/Panel.lua
+++ b/common/engine/Panel.lua
@@ -1,5 +1,4 @@
 local class = require("common.lib.class")
-local Signal = require("common.lib.signal")
 require("common.lib.util")
 
 ---@class Panel
@@ -159,7 +158,7 @@ end
 -- I'm not sure if there are better ways to represent this kind of mixin, spamming the Union type Panel | Signal everywhere felt dumb
 
 -- Represents an individual panel in a stack
----@class Panel: Signal
+---@class Panel
 ---@overload fun(id: integer, row: integer, column: integer, frameTimes: table<string, integer>): Panel
 Panel = class(
 ---@param p Panel
@@ -169,10 +168,6 @@ function(p, id, row, column, frameTimes)
   p.row = row
   p.column = column
   p.frameTimes = frameTimes
-  Signal.turnIntoEmitter(p)
-  p:createSignal("pop")
-  p:createSignal("popped")
-  p:createSignal("land")
 end
 )
 
@@ -258,7 +253,7 @@ end
 -- makes the panel enter landing state and informs the stack about the event depending on whether it's garbage or not
 ---@param panel Panel
 local function land(panel)
-  panel:emitSignal("land", panel)
+  panel:onLand()
   if panel.isGarbage then
     panel.state = "normal"
   else
@@ -487,7 +482,7 @@ matchedState.update = function(panel, panels)
   if panel.isGarbage and panel.timer == panel.pop_time then
     -- technically this is criminal and garbage panels should enter popping state too
     -- there is also little reason why garbage uses pop_time and normal panels timer
-    panel:emitSignal("pop", panel)
+    panel:onPop()
   end
   if panel.timer == 0 then
     matchedState.changeState(panel, panels)
@@ -544,7 +539,7 @@ end
 ---@param panel Panel
 ---@param panels Panel[][]
 poppingState.changeState = function(panel, panels)
-  panel:emitSignal("pop", panel)
+  panel:onPop()
   -- If it is the last panel to pop, it has to skip popped state
   if panel.combo_size == panel.combo_index then
     poppedState.changeState(panel, panels)
@@ -569,7 +564,7 @@ end
 poppedState.changeState = function(panel, panels)
   -- It's time for this panel
   -- to be gone forever :'(
-  panel:emitSignal("popped", panel)
+  panel:onPopped()
   clear(panel, true, true)
   -- Flag so panels above can know whether they should be chaining or not
   panel.propagatesChaining = true
@@ -863,6 +858,18 @@ function Panel:match(isChainLink, comboIndex, comboSize)
   end
   self.combo_index = comboIndex
   self.combo_size = comboSize
+end
+
+function Panel:onPop()
+  error("Did not implement Panel:onPop()")
+end
+
+function Panel:onPopped()
+  error("Did not implement Panel:onPopped()")
+end
+
+function Panel:onLand()
+  error("Did not implement Panel:onLand()")
 end
 
 return Panel

--- a/common/engine/RollbackBuffer.lua
+++ b/common/engine/RollbackBuffer.lua
@@ -72,4 +72,26 @@ function RollbackBuffer:rollbackToFrame(frame)
   end
 end
 
+function RollbackBuffer:peekPrevious()
+  local previousIndex = wrap(1, self.currentIndex - 1, self.size)
+  return self.buffer[previousIndex]
+end
+
+---@return integer
+function RollbackBuffer:getSize()
+  local size = 0
+  local index = self.currentIndex
+  for i = 1, self.size do
+    index = wrap(1, index - 1, self.size)
+
+    if not self.frames[index] then
+      return size
+    end
+
+    size = size + 1
+  end
+
+  return size
+end
+
 return RollbackBuffer

--- a/common/engine/RollbackBuffer.lua
+++ b/common/engine/RollbackBuffer.lua
@@ -77,14 +77,14 @@ function RollbackBuffer:peekPrevious()
   return self.buffer[previousIndex]
 end
 
----@return integer
-function RollbackBuffer:getSize()
+---@return integer # how many usable rollback copies are stored in the buffer
+function RollbackBuffer:getStoredCopyCount()
   local size = 0
   local index = self.currentIndex
   for i = 1, self.size do
     index = wrap(1, index - 1, self.size)
 
-    if not self.frames[index] then
+    if not self.frames[index] or self.frames[index] == -1 then
       return size
     end
 

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -345,7 +345,7 @@ function Stack:rollbackCopy()
   local copy = self.rollbackBuffer:getOldest()
   if copy then
     -- this is to eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
-    for i = #copy.panels, #self.panels * self.width, -1 do
+    for i = #copy.panels, (#self.panels + 1) * self.width + 1, -1 do
       copy.panels[i] = nil
     end
     -- as we're reusing tables and many panel values can be nil, it's necessary to clear out data to not have false data linger

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -1768,7 +1768,7 @@ function Stack:getInfo()
   info.playerNumber = self.which
   info.inputMethod = self.inputMethod
   info.rollbackCount = self.rollbackCount
-  info.rollbackCopyCount = self.rollbackBuffer:getSize()
+  info.rollbackCopyCount = self.rollbackBuffer:getStoredCopyCount()
 
   return info
 end

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -320,11 +320,31 @@ function Stack.divergenceString(stackToTest)
   return result
 end
 
+function Stack:rollbackCopyPanels(copy)
+  local panels = copy.panels or {}
+
+  -- rollback data for panels is saved in an unrolled format to avoid creating dozens of extra tables for storage
+  -- panels are saved in a flat table and indexed left to right, going up from row 0
+  for i = 0, #self.panels do
+    for j = 1, self.width do
+      local index = i * self.width + j
+      -- if it's a fresh copy or the current stack is higher than the stale copy there may not be any preexisting table at this location
+      panels[index] = panels[index] or {}
+      local sPanel = self.panels[i][j]
+      for k, v in pairs(sPanel) do
+        panels[index][k] = v
+      end
+    end
+  end
+
+  return panels
+end
+
 -- saves a copy of the stack with its current clock within its rollback buffer
 function Stack:rollbackCopy()
   local copy = self.rollbackBuffer:getOldest()
   if copy then
-    -- this is too eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
+    -- this is to eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
     for i = #copy.panels, #self.panels * self.width, -1 do
       copy.panels[i] = nil
     end
@@ -381,22 +401,10 @@ function Stack:rollbackCopy()
     copy.currentGarbageDropColumnIndexes[garbageWidth] = self.currentGarbageDropColumnIndexes[garbageWidth]
   end
 
-  copy.panels = copy.panels or {}
   copy.panelsCreatedCount = self.panelsCreatedCount
-
-  -- rollback data for panels is saved in an unrolled format to avoid creating dozens of extra tables for storage
-  -- panels are saved in a flat table and indexed left to right, going up from row 0
-  for i = 0, #self.panels do
-    for j = 1, self.width do
-      local index = i * self.width + j
-      -- if it's a fresh copy or the current stack is higher than the stale copy there may not be any preexisting table at this location
-      copy.panels[index] = copy.panels[index] or {}
-      local sPanel = self.panels[i][j]
-      for k, v in pairs(sPanel) do
-        copy.panels[index][k] = v
-      end
-    end
-  end
+  prof.push("rollbackCopyPanels")
+  copy.panels = self:rollbackCopyPanels(copy)
+  prof.pop("rollbackCopyPanels")
 
   self.rollbackBuffer:saveCopy(self.clock, copy)
 end
@@ -453,17 +461,17 @@ local function internalRollbackToFrame(stack, frame)
   stack.currentGarbageDropColumnIndexes = copy.currentGarbageDropColumnIndexes
 
   -- roll up the panel copies into the table structure
-  for i, panel in ipairs(copy.panels) do
-    local row = panel.row
-    local column = panel.column
+  for i, panelCopy in ipairs(copy.panels) do
+    local row = panelCopy.row
+    local column = panelCopy.column
 
     if stack.panels[row][column] then
       table.clear(stack.panels[row][column])
     else
-      stack.panels[row][column] = stack.panelTemplate(panel.id, row, column)
+      stack.panels[row][column] = stack.panelTemplate(panelCopy.id, row, column)
     end
 
-    for k, v in pairs(panel) do
+    for k, v in pairs(panelCopy) do
       stack.panels[row][column][k] = v
     end
   end

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -138,6 +138,7 @@ local PANELS_TO_NEXT_SPEED =
 ---@field puzzle table? Optional puzzle
 ---@field game_stopwatch integer? Clock time minus time that swaps were blocked
 ---@field rollbackBuffer RollbackBuffer
+---@field rollbackPanelBuffer Panel[]
 ---@field panelTemplate (Panel | fun(id: integer, row: integer, column: integer): Panel) A template class based on Panel enriched by tailor made closures containing references to the Stack
 
 
@@ -260,6 +261,7 @@ local Stack = class(
     s.garbageGenCount = 0
 
     s.rollbackBuffer = RollbackBuffer(MAX_LAG + 1)
+    s.rollbackPanelBuffer = {}
 
     s.warningsTriggered = {}
 
@@ -329,11 +331,20 @@ function Stack:rollbackCopyPanels(copy)
     for j = 1, self.width do
       local index = i * self.width + j
       -- if it's a fresh copy or the current stack is higher than the stale copy there may not be any preexisting table at this location
-      panels[index] = panels[index] or {}
+      local panelCopy = panels[index]
+      if not panelCopy then
+        if #self.rollbackPanelBuffer > 0 then
+          panelCopy = table.remove(self.rollbackPanelBuffer)
+        else
+          -- panels have 13 base props and up to 11 garbage specific props OR 7 non-garbage specific props
+          panelCopy = table.new(0, 24)
+        end
+      end
       local sPanel = self.panels[i][j]
       for k, v in pairs(sPanel) do
-        panels[index][k] = v
+        panelCopy[k] = v
       end
+      panels[index] = panelCopy
     end
   end
 
@@ -344,13 +355,15 @@ end
 function Stack:rollbackCopy()
   local copy = self.rollbackBuffer:getOldest()
   if copy then
-    -- this is to eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
-    for i = #copy.panels, (#self.panels + 1) * self.width + 1, -1 do
-      copy.panels[i] = nil
-    end
     -- as we're reusing tables and many panel values can be nil, it's necessary to clear out data to not have false data linger
     for i = 1, #copy.panels do
       table.clear(copy.panels[i])
+    end
+    -- this is to eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
+    for i = #copy.panels, (#self.panels + 1) * self.width + 1, -1 do
+      -- but as offscreen rows come and go and we don't want to reallocate them every time, buffer them as well!
+      self.rollbackPanelBuffer[#self.rollbackPanelBuffer+1] = copy.panels[i]
+      copy.panels[i] = nil
     end
   else
     copy = {panels = {}, currentGarbageDropColumnIndexes = {}}

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -262,6 +262,13 @@ local Stack = class(
 
     s.rollbackBuffer = RollbackBuffer(MAX_LAG + 1)
     s.rollbackPanelBuffer = {}
+    -- this is a bit of an opportunistic thing:
+    -- one issue with rollback is that it allocates a ton of memory while it boots up which in turn accelerates the garbage collector
+    -- that creates a situation where more memory is allocated, the GC starts running faster and the odds of having to run double updates for the opponent is high
+    -- by preallocating memory for the panels (which is responsible for 90% of rollback memory), the load is less concentrated and stacks are generally more "rollback ready"
+    for i = 1, ((s.height + 1) * s.width) * MAX_LAG do
+      s.rollbackPanelBuffer[#s.rollbackPanelBuffer+1] = table.new(0, 24)
+    end
 
     s.warningsTriggered = {}
 

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -15,6 +15,7 @@ local LevelData = require("common.data.LevelData")
 table.clear = require("table.clear")
 local ReplayPlayer = require("common.data.ReplayPlayer")
 local TouchInputController = require("common.engine.TouchInputController")
+local RollbackBuffer = require("common.engine.RollbackBuffer")
 
 -- Stuff defined in this file:
 --  . the data structures that store the configuration of
@@ -137,6 +138,8 @@ local PANELS_TO_NEXT_SPEED =
 ---@field warningsTriggered table ancient ancient, probably remove
 ---@field puzzle table? Optional puzzle
 ---@field game_stopwatch integer? Clock time minus time that swaps were blocked
+---@field rollbackBuffer RollbackBuffer
+---@field panelTemplate (Panel | fun(id: integer, row: integer, column: integer): Panel) A template class based on Panel enriched by tailor made closures containing references to the Stack
 
 
 -- Represents the full panel stack for one player
@@ -201,6 +204,8 @@ local Stack = class(
     s.panels = {}
     s.width = 6
     s.height = 12
+    s.panelTemplate = s:createPanelTemplate()
+
     for i = 0, s.height do
       s.panels[i] = {}
       for j = 1, s.width do
@@ -256,6 +261,8 @@ local Stack = class(
     s.panelGenCount = 0
     s.garbageGenCount = 0
 
+    s.rollbackBuffer = RollbackBuffer(MAX_LAG + 1)
+
     s.warningsTriggered = {}
 
     s:createSignal("matched")
@@ -270,6 +277,23 @@ local Stack = class(
 )
 
 Stack.TYPE = "Stack"
+
+---@return (Panel | fun(id: integer, row: integer, column: integer): Panel)
+function Stack:createPanelTemplate()
+  local panelTemplate = class(function(p, id, row, column) end, Panel)
+  panelTemplate.frameTimes = self.levelData.frameConstants
+  panelTemplate.onPop = function(panel)
+    self:onPop(panel)
+  end
+  panelTemplate.onPopped = function(panel)
+    self:onPopped(panel)
+  end
+  panelTemplate.onLand = function(panel)
+    self:onLand(panel)
+  end
+
+  return panelTemplate
+end
 
 function Stack.divergenceString(stackToTest)
   local result = ""
@@ -1577,16 +1601,13 @@ function Stack:getAttackPatternData()
 end
 
 -- creates a new panel at the specified row+column and adds it to the Stack's panels table
----@param self table
+---@param self Stack
 ---@param row integer
 ---@param column integer
 ---@return Panel panel New Panel at the specified row+column that has been added to the Stack's panels table and subscribed to for signals
 function Stack.createPanelAt(self, row, column)
   self.panelsCreatedCount = self.panelsCreatedCount + 1
-  local panel = Panel(self.panelsCreatedCount, row, column, self.levelData.frameConstants)
-  panel:connectSignal("pop", self, self.onPop)
-  panel:connectSignal("popped", self, self.onPopped)
-  panel:connectSignal("land", self, self.onLand)
+  local panel = self.panelTemplate(self.panelsCreatedCount, row, column)
   self.panels[row][column] = panel
   return panel
 end

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -81,7 +81,6 @@ local PANELS_TO_NEXT_SPEED =
 --- will get periodically extended as it gets consumed
 ---@field inputMethod string "controller" or "touch", determines how inputs are interpreted internally
 ---@field touchInputController table
----@field input_buffer string[] Inputs that haven't been processed yet
 ---@field confirmedInput string[] All inputs the player has input so far (or ever)
 ---@field input_state string The input for the current frame
 ---@field package garbageCreatedCount integer The number of individual garbage blocks created on this stack \n
@@ -195,7 +194,6 @@ local Stack = class(
 
     s.panel_buffer = ""
     s.gpanel_buffer = ""
-    s.input_buffer = {}
     s.confirmedInput = {}
     s.garbageCreatedCount = 0
     s.garbageLandedThisFrame = {}
@@ -438,12 +436,6 @@ local function internalRollbackToFrame(stack, frame)
   if frame < currentFrame and stack.rollbackCopies[frame] then
     logger.debug("Rolling back " .. stack.which .. " to " .. frame)
     Stack.rollbackCopy(stack.rollbackCopies[frame], stack)
-    -- The remaining inputs is the confirmed inputs not processed yet for this clock time
-    -- We have processed clock time number of inputs when we are at clock, so we only want to process the clock+1 input on
-    stack.input_buffer = {}
-    for i = stack.clock + 1, #stack.confirmedInput do
-      stack.input_buffer[#stack.input_buffer+1] = stack.confirmedInput[i]
-    end
     -- this is for the interpolation of the shake animation only (not a physics relevant field)
     if stack.rollbackCopies[frame - 1] then
       stack.prev_shake_time = stack.rollbackCopies[frame - 1].shake_time
@@ -547,7 +539,6 @@ function Stack:resetPuzzle()
 
   self:setPuzzleState(self.puzzle)
   self.confirmedInput = {}
-  self.input_buffer = {}
   self.clock = 0
   self.game_stopwatch = 0
   self.game_stopwatch_running = false
@@ -832,7 +823,7 @@ function Stack:shouldRun(runsSoFar)
   end
 
   -- Decide how many frames of input we should run.
-  local buffer_len = #self.input_buffer
+  local buffer_len = #self.confirmedInput - self.clock
 
   -- If we are local we always want to catch up and run the new input which is already appended
   if self.is_local then
@@ -862,7 +853,7 @@ function Stack.run(self)
 
   if self.is_local == false then
     if self.play_to_end then
-      if #self.input_buffer < 4 then
+      if #self.confirmedInput - self.clock < 4 then
         self.play_to_end = nil
       end
     end
@@ -888,9 +879,7 @@ function Stack.setupInput(self)
   self.input_state = nil
 
   if self:game_ended() == false then
-    if self.input_buffer and #self.input_buffer > 0 then
-      self.input_state = table.remove(self.input_buffer, 1)
-    end
+    self.input_state = self.confirmedInput[self.clock + 1]
   else
     self.input_state = self:idleInput()
   end
@@ -901,11 +890,9 @@ end
 function Stack.receiveConfirmedInput(self, input)
   if utf8.len(input) == 1 then
     self.confirmedInput[#self.confirmedInput+1] = input
-    self.input_buffer[#self.input_buffer+1] = input
   else
     local inputs = string.toCharTable(input)
     tableUtils.appendToList(self.confirmedInput, inputs)
-    tableUtils.appendToList(self.input_buffer, inputs)
   end
   --logger.debug("Player " .. self.which .. " got new input. Total length: " .. #self.confirmedInput)
 end

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -320,140 +320,173 @@ function Stack.divergenceString(stackToTest)
   return result
 end
 
--- Backup important variables into the passed in variable to be restored in rollback. Note this doesn't do a full copy.
--- param source the stack to copy from
--- param other the variable to copy to (this may be a full stack object in the case of restore, or just a table in case of backup)
-function Stack.rollbackCopy(source, other)
-  local restoringStack = getmetatable(other) ~= nil
-
-  if other == nil then
-    if #source.rollbackCopyPool == 0 then
-      other = {}
-    else
-      other = source.rollbackCopyPool[#source.rollbackCopyPool]
-      source.rollbackCopyPool[#source.rollbackCopyPool] = nil
+-- saves a copy of the stack with its current clock within its rollback buffer
+function Stack:rollbackCopy()
+  local copy = self.rollbackBuffer:getOldest()
+  if copy then
+    -- this is too eliminate offscreen rows of chain garbage higher up from the old copy so they don't linger in the new copy
+    for i = #copy.panels, #self.panels * self.width, -1 do
+      copy.panels[i] = nil
     end
-  end
-  other.queuedSwapColumn = source.queuedSwapColumn
-  other.queuedSwapRow = source.queuedSwapRow
-  other.speed = source.speed
-  other.health = source.health
-
-  if other.currentGarbageDropColumnIndexes == nil then
-    other.currentGarbageDropColumnIndexes = {}
-  end
-  for garbageWidth = 1, #source.currentGarbageDropColumnIndexes do
-    other.currentGarbageDropColumnIndexes[garbageWidth] = source.currentGarbageDropColumnIndexes[garbageWidth]
+    -- as we're reusing tables and many panel values can be nil, it's necessary to clear out data to not have false data linger
+    for i = 1, #copy.panels do
+      table.clear(copy.panels[i])
+    end
+  else
+    copy = {panels = {}, currentGarbageDropColumnIndexes = {}}
   end
 
-  prof.push("rollback copy panels")
-  local width = source.width or other.width
-  local height_to_cpy = #source.panels
-  other.panels = other.panels or {}
-  local startRow = 1
-  if source.panels[0] then
-    startRow = 0
+  copy.queuedSwapColumn = self.queuedSwapColumn
+  copy.queuedSwapRow = self.queuedSwapRow
+  copy.speed = self.speed
+  copy.health = self.health
+  copy.countdown_timer = self.countdown_timer
+  copy.clock = self.clock
+  copy.game_stopwatch = self.game_stopwatch
+  copy.game_stopwatch_running = self.game_stopwatch_running
+  copy.rise_lock = self.rise_lock
+  copy.top_cur_row = self.top_cur_row
+  copy.displacement = self.displacement
+  copy.nextSpeedIncreaseClock = self.nextSpeedIncreaseClock
+  copy.panels_to_speedup = self.panels_to_speedup
+  copy.stop_time = self.stop_time
+  copy.pre_stop_time = self.pre_stop_time
+  copy.score = self.score
+  copy.chain_counter = self.chain_counter
+  copy.n_active_panels = self.n_active_panels
+  copy.n_prev_active_panels = self.n_prev_active_panels
+  copy.rise_timer = self.rise_timer
+  copy.manual_raise = self.manual_raise
+  copy.manual_raise_yet = self.manual_raise_yet
+  copy.prevent_manual_raise = self.prevent_manual_raise
+  copy.cur_timer = self.cur_timer
+  copy.cur_dir = self.cur_dir
+  copy.cur_row = self.cur_row
+  copy.cur_col = self.cur_col
+  copy.shake_time = self.shake_time
+  copy.peak_shake_time = self.peak_shake_time
+  copy.do_countdown = self.do_countdown
+  copy.panel_buffer = self.panel_buffer
+  copy.gpanel_buffer = self.gpanel_buffer
+  copy.panelGenCount = self.panelGenCount
+  copy.garbageGenCount = self.garbageGenCount
+  copy.panels_in_top_row = self.panels_in_top_row
+  copy.has_risen = self.has_risen
+  copy.metal_panels_queued = self.metal_panels_queued
+  copy.panels_cleared = self.panels_cleared
+  copy.game_over_clock = self.game_over_clock
+  copy.highestGarbageIdMatched = self.highestGarbageIdMatched
+
+  for garbageWidth = 1, #self.currentGarbageDropColumnIndexes do
+    copy.currentGarbageDropColumnIndexes[garbageWidth] = self.currentGarbageDropColumnIndexes[garbageWidth]
   end
-  other.panelsCreatedCount = source.panelsCreatedCount
-  for i = startRow, height_to_cpy do
-    if other.panels[i] == nil then
-      other.panels[i] = {}
-      for j = 1, width do
-        if restoringStack then
-          other:createPanelAt(i, j) -- the panel ID will be overwritten below
-        else
-          -- We don't need to "create" a panel, since we are just backing up the key values
-          -- and when we restore we will usually have a panel to restore into.
-          other.panels[i][j] = {}
-        end
+
+  copy.panels = copy.panels or {}
+  copy.panelsCreatedCount = self.panelsCreatedCount
+
+  -- rollback data for panels is saved in an unrolled format to avoid creating dozens of extra tables for storage
+  -- panels are saved in a flat table and indexed left to right, going up from row 0
+  for i = 0, #self.panels do
+    for j = 1, self.width do
+      local index = i * self.width + j
+      -- if it's a fresh copy or the current stack is higher than the stale copy there may not be any preexisting table at this location
+      copy.panels[index] = copy.panels[index] or {}
+      local sPanel = self.panels[i][j]
+      for k, v in pairs(sPanel) do
+        copy.panels[index][k] = v
       end
     end
-    for j = 1, width do
-      local opanel = other.panels[i][j]
-      local spanel = source.panels[i][j]
-      -- Clear all variables not in source, then copy all source variables to the backup
-      -- Note the functions are kept from the same stack so they will still be valid
-      for k, _ in pairs(opanel) do
-        if spanel[k] == nil then
-          opanel[k] = nil
-        end
-      end
-      for k, v in pairs(spanel) do
-        opanel[k] = v
-      end
-    end
   end
-  -- this is too eliminate offscreen rows of chain garbage higher up that the clone might have had
-  for i = height_to_cpy + 1, #other.panels do
-    other.panels[i] = nil
-  end
-  prof.pop("rollback copy panels")
 
-  prof.push("rollback copy the rest")
-  other.countdown_timer = source.countdown_timer
-  other.clock = source.clock
-  other.game_stopwatch = source.game_stopwatch
-  other.game_stopwatch_running = source.game_stopwatch_running
-  other.rise_lock = source.rise_lock
-  other.top_cur_row = source.top_cur_row
-  other.displacement = source.displacement
-  other.nextSpeedIncreaseClock = source.nextSpeedIncreaseClock
-  other.panels_to_speedup = source.panels_to_speedup
-  other.stop_time = source.stop_time
-  other.pre_stop_time = source.pre_stop_time
-  other.score = source.score
-  other.chain_counter = source.chain_counter
-  other.n_active_panels = source.n_active_panels
-  other.n_prev_active_panels = source.n_prev_active_panels
-  other.rise_timer = source.rise_timer
-  other.manual_raise = source.manual_raise
-  other.manual_raise_yet = source.manual_raise_yet
-  other.prevent_manual_raise = source.prevent_manual_raise
-  other.cur_timer = source.cur_timer
-  other.cur_dir = source.cur_dir
-  other.cur_row = source.cur_row
-  other.cur_col = source.cur_col
-  other.shake_time = source.shake_time
-  other.peak_shake_time = source.peak_shake_time
-  other.do_countdown = source.do_countdown
-  other.panel_buffer = source.panel_buffer
-  other.gpanel_buffer = source.gpanel_buffer
-  other.panelGenCount = source.panelGenCount
-  other.garbageGenCount = source.garbageGenCount
-  other.panels_in_top_row = source.panels_in_top_row
-  other.has_risen = source.has_risen
-  other.metal_panels_queued = source.metal_panels_queued
-  other.panels_cleared = source.panels_cleared
-  other.game_over_clock = source.game_over_clock
-  other.highestGarbageIdMatched = source.highestGarbageIdMatched
-  prof.pop("rollback copy the rest")
-
-  return other
+  self.rollbackBuffer:saveCopy(self.clock, copy)
 end
 
 local function internalRollbackToFrame(stack, frame)
-  local currentFrame = stack.clock
-  if frame < currentFrame and stack.rollbackCopies[frame] then
-    logger.debug("Rolling back " .. stack.which .. " to " .. frame)
-    Stack.rollbackCopy(stack.rollbackCopies[frame], stack)
-    -- this is for the interpolation of the shake animation only (not a physics relevant field)
-    if stack.rollbackCopies[frame - 1] then
-      stack.prev_shake_time = stack.rollbackCopies[frame - 1].shake_time
-    else
-      -- if this is the oldest rollback frame we don't need to interpolate with previous values
-      -- because there are no previous values, pretend it just went down smoothly
-      -- this can lead to minor differences in display for the same frame when using rewind
-      stack.prev_shake_time = stack.shake_time + 1
-    end
+  local copy = stack.rollbackBuffer:rollbackToFrame(frame)
 
-    for f = frame, currentFrame do
-      stack:deleteRollbackCopy(f)
-    end
-
-    return true
+  if not copy then
+    return false
   end
 
-  return false
+  stack.countdown_timer = copy.countdown_timer
+  stack.clock = copy.clock
+  stack.game_stopwatch = copy.game_stopwatch
+  stack.game_stopwatch_running = copy.game_stopwatch_running
+  stack.rise_lock = copy.rise_lock
+  stack.top_cur_row = copy.top_cur_row
+  stack.displacement = copy.displacement
+  stack.nextSpeedIncreaseClock = copy.nextSpeedIncreaseClock
+  stack.panels_to_speedup = copy.panels_to_speedup
+  stack.stop_time = copy.stop_time
+  stack.pre_stop_time = copy.pre_stop_time
+  stack.score = copy.score
+  stack.chain_counter = copy.chain_counter
+  stack.n_active_panels = copy.n_active_panels
+  stack.n_prev_active_panels = copy.n_prev_active_panels
+  stack.rise_timer = copy.rise_timer
+  stack.manual_raise = copy.manual_raise
+  stack.manual_raise_yet = copy.manual_raise_yet
+  stack.prevent_manual_raise = copy.prevent_manual_raise
+  stack.cur_timer = copy.cur_timer
+  stack.cur_dir = copy.cur_dir
+  stack.cur_row = copy.cur_row
+  stack.cur_col = copy.cur_col
+  stack.shake_time = copy.shake_time
+  stack.peak_shake_time = copy.peak_shake_time
+  stack.do_countdown = copy.do_countdown
+  stack.panel_buffer = copy.panel_buffer
+  stack.gpanel_buffer = copy.gpanel_buffer
+  stack.panelGenCount = copy.panelGenCount
+  stack.garbageGenCount = copy.garbageGenCount
+  stack.panels_in_top_row = copy.panels_in_top_row
+  stack.has_risen = copy.has_risen
+  stack.metal_panels_queued = copy.metal_panels_queued
+  stack.panels_cleared = copy.panels_cleared
+  stack.game_over_clock = copy.game_over_clock
+  stack.highestGarbageIdMatched = copy.highestGarbageIdMatched
+  stack.queuedSwapColumn = copy.queuedSwapColumn
+  stack.queuedSwapRow = copy.queuedSwapRow
+  stack.speed = copy.speed
+  stack.health = copy.health
+
+  -- we can just overwrite using the copied table as the rollbackBuffer discards that table from reuse
+  stack.currentGarbageDropColumnIndexes = copy.currentGarbageDropColumnIndexes
+
+  -- roll up the panel copies into the table structure
+  for i, panel in ipairs(copy.panels) do
+    local row = panel.row
+    local column = panel.column
+
+    if stack.panels[row][column] then
+      table.clear(stack.panels[row][column])
+    else
+      stack.panels[row][column] = stack.panelTemplate(panel.id, row, column)
+    end
+
+    for k, v in pairs(panel) do
+      stack.panels[row][column][k] = v
+    end
+  end
+
+  -- we need to cut off any offscreen panels that were not there in the copied data
+  -- -1 cause we always have a row 0 at the beginning of copy.panels, +1 because we don't actually want to remove the top most row
+  local maxRow = #copy.panels / stack.width -- - 1 + 1
+  for i = #stack.panels, maxRow, -1 do
+    stack.panels[i] = nil
+  end
+
+  -- this is for the interpolation of the shake animation only (not a physics relevant field)
+  local previousData = stack.rollbackBuffer:peekPrevious()
+  if previousData.clock == frame - 1 then
+    stack.prev_shake_time = previousData.shake_time
+  else
+    -- if this is the oldest rollback frame we don't need to interpolate with previous values
+    -- because there are no previous values, pretend it just went down smoothly
+    -- this can lead to minor differences in display for the same frame when using rewind
+    stack.prev_shake_time = stack.shake_time + 1
+  end
+
+  return true
 end
 
 ---@param frame integer the frame to rollback to if possible
@@ -505,7 +538,7 @@ function Stack.saveForRollback(self)
   prof.push("Stack:saveForRollback")
   self:remove_extra_rows()
   prof.push("Stack.rollbackCopy")
-  self.rollbackCopies[self.clock] = Stack.rollbackCopy(self)
+  self:rollbackCopy()
   prof.pop("Stack.rollbackCopy")
   prof.push("incomingGarbage:rollbackCopy")
   self.incomingGarbage:rollbackCopy(self.clock)
@@ -515,20 +548,8 @@ function Stack.saveForRollback(self)
     self.outgoingGarbage:rollbackCopy(self.clock)
   end
   prof.pop("outgoingGarbage:rollbackCopy")
-
-  prof.push("delete rollback copy")
-  local deleteFrame = self.clock - MAX_LAG - 1
-  self:deleteRollbackCopy(deleteFrame)
-  prof.pop("delete rollback copy")
   prof.pop("Stack:saveForRollback")
   self:emitSignal("rollbackSaved", self.clock)
-end
-
-function Stack.deleteRollbackCopy(self, frame)
-  if self.rollbackCopies[frame] then
-    self.rollbackCopyPool[#self.rollbackCopyPool + 1] = self.rollbackCopies[frame]
-    self.rollbackCopies[frame] = nil
-  end
 end
 
 -- will throw an error if there is no puzzle set
@@ -1719,11 +1740,7 @@ function Stack:getInfo()
   info.playerNumber = self.which
   info.inputMethod = self.inputMethod
   info.rollbackCount = self.rollbackCount
-  if self.rollbackCopies then
-    info.rollbackCopyCount = tableUtils.length(self.rollbackCopies)
-  else
-    info.rollbackCopyCount = 0
-  end
+  info.rollbackCopyCount = self.rollbackBuffer:getSize()
 
   return info
 end

--- a/common/tests/engine/StackReplayTestingUtils.lua
+++ b/common/tests/engine/StackReplayTestingUtils.lua
@@ -95,7 +95,7 @@ function StackReplayTestingUtils:simulateMatchUntil(match, clockGoal)
   assert(match.stacks[1].is_local == false, "Don't use 'local' for tests, we might simulate the clock time too much if local")
   while match.stacks[1].clock < clockGoal do
     assert(not match:hasEnded(), "Game isn't expected to end yet")
-    assert(#match.stacks[1].input_buffer > 0)
+    assert(#match.stacks[1].confirmedInput > match.stacks[1].clock)
     match:run()
   end
   assert(match.stacks[1].clock == clockGoal)

--- a/common/tests/engine/StackReplayTests.lua
+++ b/common/tests/engine/StackReplayTests.lua
@@ -398,7 +398,7 @@ local function platformTest(waitFrames, useMatchSide)
 
   local fullInputs = ReplayPlayer.decompressInputString(compressedInputs)
   stack:receiveConfirmedInput(fullInputs) -- make the clear and then do the platform
-  assert(#match.stacks[1].input_buffer > 0)
+  assert(#match.stacks[1].confirmedInput > match.stacks[1].clock)
   StackReplayTestingUtils:fullySimulateMatch(match)
   assert(match.stacks[1].clock == 134)
   assert(tableUtils.count(match.stacks[1].outgoingGarbage.history, function(g) return g.isChain end) == 1)

--- a/common/tests/lib/InputTests.lua
+++ b/common/tests/lib/InputTests.lua
@@ -23,7 +23,7 @@ local function testSameFrameKeyPressRelease()
   match.stacks[1]:receiveConfirmedInput(string.rep(match.stacks[1]:idleInput(), 200))
   while match.stacks[1].clock < 200 do
     assert(not match:hasEnded(), "Game isn't expected to end yet")
-    assert(#match.stacks[1].input_buffer > 0)
+    assert(#match.stacks[1].confirmedInput > match.stacks[1].clock)
     match:run()
   end
   assert(match.stacks[1].clock == 200)

--- a/docs/Understanding the Codebase.md
+++ b/docs/Understanding the Codebase.md
@@ -253,8 +253,8 @@ As a short version for understanding "roughly" what is going on as part of a sin
 Inside of a `BattleRoom`, after the `Player` has readied up a `ClientMatch` is being created and started.  
 In the start process, a `PlayerStack` is being constructed via the constructor `PlayerStack = class(... etc)` based on the `Player`'s settings.  
 Every frame, `ClientMatch:run()` is called on the game scene which in turn runs the engine match and the `Stack`s.  
-Via `inputManager.lua`, there are inputs injected to the `Stack`'s `input_buffer` via `receiveConfirmedInput`.
-`Stack.run` applies the input as part of `Stack.simulate` and advances its state by one frame.  
+Via `inputManager.lua`, there are inputs injected to the `Stack`'s `confirmedInput` via `receiveConfirmedInput`.
+`Stack.run` applies the inputs as part of `Stack.simulate` and advances its state by one frame.  
 If you read the comments for `Stack.simulate`, you may notice a suspicious absence of phase 1 and 2, mostly because they already got extracted into separate functions.
 
 ### Replays and Interoperability


### PR DESCRIPTION
Closes #609, implemented pretty much as written.

Additional ways to speed things up:
Instead of registering the onPop/onPopped/onLand callbacks with each panel individually, each Stack now creates a template for its panels on creation which includes these functions and is used as the metatable for new panels on that stack, replacing the indirection of the Signal with the indirection of the metatable. More importantly it removes the Signal related fields from the panel so less data has to be kept and copied.

`Stack` adopts the `RollbackBuffer`. The old way had both saving data and restoring data being in the same function which made things unwieldy and complex. The new way is built on the premise that there is only one primary object that creates backup data with one function and reapplies it to itself with another function which makes things easier and reduces the amount of branching necessary for each use case.

Previously, panels that were in offscreen rows were often discarded. Say frame 2432 had garbage panels in row 14. In frame 2647 that rollback data went stale and was reused but if that frame did not have panels in row 14 those panels would have been discarded and for a next chain garbage drop, new panels would be allocated.
Each stack now has an additional internal buffer for keeping allocations of panel rollback data. That means in the inverse case with stale data only having 12 rows but the data we want to save having 14 rows, the tables can be taken out of the buffer first and only allocate new memory when it is empty.

The old system iterated via pairs to clear out data from stale panels, the new one uses table.clear for easier syntax and eliminates the need to check with the panel we want to copy.
Additionally panel data is allocated via table.new to avoid rehashes when building the data.

Finally, stacks now preallocate panel data for rollback so that the burden of increased allocations and momentarily faster GC does not coincide with possibly running double or triple updates for the remote stack. The preallocations account for ~20MB per stack which is reasonable.

The engine-only tests (which are to a greater degree replay based) speed up from ~17s to ~13s on my machine. Honestly not that much but given that the rollback code on Stack looks a lot nicer now, any speedup is just a bonus.