### PR TITLE
Fix replay saving

### DIFF
--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -284,16 +284,6 @@ function BattleRoom:addPlayer(player)
   end
   self.players[#self.players + 1] = player
 
-  -- make sure the local player ends up as P1 (left side)
-  -- if both are local or both are not, order by playerNumber
-  table.sort(self.players, function(a, b)
-    if a.isLocal == b.isLocal then
-      return a.playerNumber < b.playerNumber
-    else
-      return a.isLocal
-    end
-  end)
-
   if player.isLocal then
     self:connectSignal("allAssetsLoadedChanged", player, player.setLoaded)
   end

--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -124,6 +124,9 @@ function BattleRoom.createFromServerMessage(message)
       if player.name == GAME.localPlayer.name then
         logger.debug("Local player is player number " .. player.playerNumber)
         p = GAME.localPlayer
+        if GAME.localPlayer.publicId < 0 and player.publicId > 0 then
+          GAME.localPlayer.publicId = player.publicId
+        end
       else
         p = Player(player.name, player.publicId or -i, false)
       end
@@ -545,7 +548,6 @@ function BattleRoom:shutdown()
     GAME.netClient:leaveRoom()
   end
   self.hasShutdown = true
-  GAME:initializeLocalPlayer()
   GAME.battleRoom = nil
   self = nil
 end

--- a/client/src/ChallengeModePlayerStack.lua
+++ b/client/src/ChallengeModePlayerStack.lua
@@ -36,14 +36,6 @@ function(self, args)
   self.sfxMetal = 0
 
   self.difficultyQuads = {}
-
-  self.stackHeightQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_multibar_shake_bar:getWidth(),
-                                                      themes[config.theme].images.IMG_multibar_shake_bar:getHeight(),
-                                                      themes[config.theme].images.IMG_multibar_shake_bar:getWidth(),
-                                                      themes[config.theme].images.IMG_multibar_shake_bar:getHeight())
-
-  -- somehow bad things happen if this is called in the base class constructor instead
-  self:moveForRenderIndex(self.which)
 end,
 ClientStack)
 
@@ -140,11 +132,11 @@ end
 
 function ChallengeModePlayerStack:renderStackHeight()
   local percentage = self.engine.healthEngine:getTopOutPercentage()
-  local xScale = (self:canvasWidth() - 8) / themes[config.theme].images.IMG_multibar_shake_bar:getWidth()
-  local yScale = (self:canvasHeight() - 4) / themes[config.theme].images.IMG_multibar_shake_bar:getHeight() * percentage
+  local xScale = (self:canvasWidth() - 8) / self.assets.multibar.shake:getWidth()
+  local yScale = (self:canvasHeight() - 4) / self.assets.multibar.shake:getHeight() * percentage
 
   GraphicsUtil.setColor(1, 1, 1, 0.6)
-  GraphicsUtil.drawQuad(themes[config.theme].images.IMG_multibar_shake_bar, self.stackHeightQuad, 4, self:canvasHeight(), 0, xScale,
+  GraphicsUtil.drawQuad(self.assets.multibar.shake, self.stackHeightQuad, 4, self:canvasHeight(), 0, xScale,
                      -yScale)
   GraphicsUtil.setColor(1, 1, 1, 1)
 end
@@ -170,8 +162,7 @@ end
 
 function ChallengeModePlayerStack:drawSpeed()
   if self.engine.healthEngine then
-    self:drawLabel(themes[config.theme].images["IMG_speed_" .. self.which .. "P"], themes[config.theme].speedLabel_Pos,
-                   themes[config.theme].speedLabel_Scale)
+    self:drawLabel(self.assets.speed, themes[config.theme].speedLabel_Pos, themes[config.theme].speedLabel_Scale)
     self:drawNumber(self.engine.healthEngine.currentRiseSpeed, themes[config.theme].speed_Pos, themes[config.theme].speed_Scale)
   end
 end
@@ -179,10 +170,8 @@ end
 -- rating is substituted for challenge mode difficulty here
 function ChallengeModePlayerStack:drawRating()
   if self.player.settings.difficulty then
-    self:drawLabel(themes[config.theme].images["IMG_rating_" .. self.which .. "P"], themes[config.theme].ratingLabel_Pos,
-                   themes[config.theme].ratingLabel_Scale, true)
-    self:drawNumber(self.player.settings.difficulty, themes[config.theme].rating_Pos,
-                    themes[config.theme].rating_Scale)
+    self:drawLabel(self.assets.rating, themes[config.theme].ratingLabel_Pos, themes[config.theme].ratingLabel_Scale, true)
+    self:drawNumber(self.player.settings.difficulty, themes[config.theme].rating_Pos, themes[config.theme].rating_Scale)
   end
 end
 
@@ -209,21 +198,29 @@ function ChallengeModePlayerStack:drawDebug()
     GraphicsUtil.printf("Clock " .. self.engine.clock, drawX, drawY)
 
     drawY = drawY + padding
-    GraphicsUtil.printf("P" .. self.which .. " Ended?: " .. tostring(self.engine:game_ended()), drawX, drawY)
+    GraphicsUtil.printf("P" .. self.renderIndex .. " Ended?: " .. tostring(self.engine:game_ended()), drawX, drawY)
   end
 end
 
 -- in the long run we should have all quads organized in a Stack.quads table
 -- that way deinit could be implemented generically in StackBase
 function ChallengeModePlayerStack:deinit()
-  self.healthQuad:release()
-  self.stackHeightQuad:release()
+  ClientStack.deinit(self)
+  GraphicsUtil:releaseQuad(self.stackHeightQuad)
   for _, quad in ipairs(self.difficultyQuads) do
     GraphicsUtil:releaseQuad(quad)
   end
 end
 
 function ChallengeModePlayerStack:runGameOver()
+end
+
+---@param assetPack IngameAssetPack
+function ChallengeModePlayerStack:assignAssets(assetPack)
+  ClientStack.assignAssets(self, assetPack)
+
+  local w, h = self.assets.multibar.shake:getDimensions()
+  self.stackHeightQuad = GraphicsUtil:newRecycledQuad(0, 0, w, h, w, h)
 end
 
 return ChallengeModePlayerStack

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -362,6 +362,27 @@ function ClientMatch:finalizeReplay()
     end
 
     Replay.finalizeReplay(self.engine, self.replay)
+
+    -- we kept player order consistent throughout from replay creation to evade issues with properties/inputs being recorded on the wrong replayPlayer
+    -- but now all the data is there so reorder the players according to display
+    local replayPlayers = shallowcpy(self.replay.players)
+
+    for _, playerStack in ipairs(self.stacks) do
+      local replayPlayer
+      for _, rp in ipairs(replayPlayers) do
+        if rp.publicId == playerStack.player.publicId then
+          replayPlayer = rp
+        end
+
+        if replayPlayer then
+          self.replay.players[playerStack.renderIndex] = replayPlayer
+          if self.replay.winnerId == replayPlayer.publicId then
+            self.replay.winnerIndex = playerStack.renderIndex
+          end
+        end
+      end
+    end
+
   end
 
   return replay

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -176,6 +176,7 @@ function ClientMatch:start()
   self.engine:setSeed(self.seed)
   self.engine:start()
 
+  -- needs to happen before garbageTargets are set as it defines the set of coordinates relevant for telegraph
   self:moveStacks()
 
   -- outgoing garbage is already correctly directed by Match
@@ -256,7 +257,6 @@ function ClientMatch:moveStacks()
 
   for i, player in ipairs(players) do
     player.stack:moveForRenderIndex(i)
-    player.stack:assignAssets(GAME.theme:getIngameAssetPack(i))
   end
 end
 
@@ -317,11 +317,13 @@ function ClientMatch:finalizeReplay()
 
     for i, replayPlayer in ipairs(replay.players) do
       local player
-      for _, p in ipairs(self.players[i]) do
-        if player.publicId == replayPlayer.publicId then
+      for _, p in ipairs(self.players) do
+        if p.publicId == replayPlayer.publicId then
           player = p
+          break
         end
       end
+      assert(player, "Didn't find player with publicId " .. tostring(replayPlayer.publicId))
 
       -- attackEngines may get their own "player" in replays even though they don't have one for the Match
       -- in these cases the attackEngine data is saved with the targeted player so let's not duplicate the data

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -167,7 +167,7 @@ function ClientMatch:start()
       attackEngineHost:setGarbageTarget(player.stack)
       player.stack:setGarbageSource(attackEngineHost)
       engineStacks[#engineStacks+1] = attackEngineHost.engine
-      self.stacks[attackEngineHost.which] = attackEngineHost
+      self.stacks[attackEngineHost.engine.which] = attackEngineHost
     end
   end
 
@@ -175,6 +175,8 @@ function ClientMatch:start()
                      {timeLimit = self.timeLimit, puzzle = self.puzzle})
   self.engine:setSeed(self.seed)
   self.engine:start()
+
+  self:moveStacks()
 
   -- outgoing garbage is already correctly directed by Match
   -- but the relationship is indirect between engine stacks to reduce coupling
@@ -239,6 +241,25 @@ function ClientMatch:deinit()
   end
 end
 
+function ClientMatch:moveStacks()
+-- we want to render the stacks in a particular order so that the local player ends up as P1 (left side)
+  -- BUT: we want to keep player indexing consistent over boundaries (client <-> replay <- server) to not mess with replay saving
+  -- so we solve the rendering requirement via a shallowcpy and assigning positions directly to the stacks rather than starting reordering shenanigans all across the code base
+  local players = shallowcpy(self.players)
+  table.sort(players, function(a, b)
+    if a.isLocal == b.isLocal then
+      return a.playerNumber < b.playerNumber
+    else
+      return a.isLocal
+    end
+  end)
+
+  for i, player in ipairs(players) do
+    player.stack:moveForRenderIndex(i)
+    player.stack:assignAssets(GAME.theme:getIngameAssetPack(i))
+  end
+end
+
 function ClientMatch:setStage(stageId)
   logger.debug("Setting match stage id to " .. (stageId or ""))
   if stageId then
@@ -295,7 +316,12 @@ function ClientMatch:finalizeReplay()
     replay:setRanked(self.ranked)
 
     for i, replayPlayer in ipairs(replay.players) do
-      local player = self.players[i]
+      local player
+      for _, p in ipairs(self.players[i]) do
+        if player.publicId == replayPlayer.publicId then
+          player = p
+        end
+      end
 
       -- attackEngines may get their own "player" in replays even though they don't have one for the Match
       -- in these cases the attackEngine data is saved with the targeted player so let's not duplicate the data
@@ -538,7 +564,7 @@ function ClientMatch:render()
     local drawY = 23
     for i = 1, #self.stacks do
       local stack = self.stacks[i]
-      GraphicsUtil.print("P" .. stack.which .." Average Latency: " .. stack.engine.framesBehind, 1, drawY)
+      GraphicsUtil.print("P" .. stack.renderIndex .." Average Latency: " .. stack.engine.framesBehind, 1, drawY)
       drawY = drawY + 11
     end
 

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -15,6 +15,7 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 local Telegraph = require("client.src.graphics.Telegraph")
 local MatchParticipant = require("client.src.MatchParticipant")
 local ChallengeModePlayerStack = require("client.src.ChallengeModePlayerStack")
+local NetworkProtocol = require("common.network.NetworkProtocol")
 
 ---@class ClientMatch
 ---@field players table[]
@@ -700,6 +701,28 @@ function ClientMatch:resetPuzzle()
   self.engine.clock = 0
   self.engine:setCountdown(engine.puzzle)
   self.players[1]:incrementWinCount()
+end
+
+---@param prefix "I" | "U"
+---@param input string
+function ClientMatch:receiveInput(prefix, input)
+  if self:hasLocalPlayer() then
+    if self.players[1].human and self.players[1].isLocal then
+      ---@diagnostic disable-next-line: param-type-mismatch
+      self.stacks[2]:receiveConfirmedInput(input)
+    elseif self.players[2].human and self.players[2].isLocal then
+      ---@diagnostic disable-next-line: param-type-mismatch
+      self.stacks[1]:receiveConfirmedInput(input)
+    end
+  else
+    if prefix == NetworkProtocol.serverMessageTypes.opponentInput.prefix then
+      ---@diagnostic disable-next-line: param-type-mismatch
+      self.stacks[2]:receiveConfirmedInput(input)
+    else
+      ---@diagnostic disable-next-line: param-type-mismatch
+      self.stacks[1]:receiveConfirmedInput(input)
+    end
+  end
 end
 
 return ClientMatch

--- a/client/src/ClientStack.lua
+++ b/client/src/ClientStack.lua
@@ -14,7 +14,6 @@ end
 ---The base class for a client side wrapper around an engine stack
 ---Supports general properties for positioning and drawing
 ---@class ClientStack : Signal
----@field which integer determines the position of the stack like an index but also serves as an id within the match
 ---@field is_local boolean if the Stack gets its inputs live from the local client or not
 ---@field character Character the character to use for drawing and sounds
 ---@field theme table the theme to determine offsets via theme for multibar and other properties
@@ -34,6 +33,8 @@ end
 ---@field danger_music boolean
 ---@field garbageSource ClientStack The stack the garbage assets are used from
 ---@field match ClientMatch
+---@field assets IngameAssetPack
+---@field renderIndex integer determines the position of the stack and how some elements are rendered
 
 ---@class ClientStack
 local ClientStack = class(
@@ -41,14 +42,12 @@ function(self, args)
   ---@class ClientStack
   self = self
 
-  assert(args.which)
   assert(args.is_local ~= nil)
   assert(args.character)
   assert(args.match)
 
-  self.which = args.which or 1
   -- player number according to the multiplayer server, for game outcome reporting 
-  self.player_number = args.player_number or self.which
+  self.player_number = args.player_number or args.which
   self.is_local = args.is_local
   self.character = characters[args.character]
   self.theme = args.theme or themes[config.theme]
@@ -68,12 +67,6 @@ function(self, args)
   -- mostly for tests / not running extra in some scenarios; should be removed once they have been adjusted
   self.canvas = true
   self.portraitFade = config.portrait_darkness / 100 -- will be set back to 0 if count down happens
-  self.healthQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight(), themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight())
-  self.multi_prestopQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_prestop_bar:getWidth(), self.theme.images.IMG_multibar_prestop_bar:getHeight(), self.theme.images.IMG_multibar_prestop_bar:getWidth(), self.theme.images.IMG_multibar_prestop_bar:getHeight())
-  self.multi_stopQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_stop_bar:getWidth(), self.theme.images.IMG_multibar_stop_bar:getHeight(), self.theme.images.IMG_multibar_stop_bar:getWidth(), self.theme.images.IMG_multibar_stop_bar:getHeight())
-  self.multi_shakeQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_shake_bar:getWidth(), self.theme.images.IMG_multibar_shake_bar:getHeight(), self.theme.images.IMG_multibar_shake_bar:getWidth(), self.theme.images.IMG_multibar_shake_bar:getHeight())
-
-  self:moveForRenderIndex(self.which)
 
   self.danger_music = false
 
@@ -87,7 +80,7 @@ function ClientStack:elementOriginX(cameFromLegacyScoreOffset, legacyOffsetIsAlr
   assert(cameFromLegacyScoreOffset ~= nil)
   assert(legacyOffsetIsAlreadyScaled ~= nil)
   local x = 546
-  if self.which == 2 then
+  if self.renderIndex == 2 then
     x = 642
   end
   if cameFromLegacyScoreOffset == false or themes[config.theme]:offsetsAreFixed() then
@@ -202,7 +195,7 @@ function ClientStack:drawNumber(number, themePositionOffset, scale, cameFromLega
   end
   local x = self:elementOriginXWithOffset(themePositionOffset, cameFromLegacyScoreOffset)
   local y = self:elementOriginYWithOffset(themePositionOffset, cameFromLegacyScoreOffset)
-  GraphicsUtil.drawPixelFont(number, themes[config.theme].fontMaps.numbers[self.which], x, y, scale, scale, "center", 0)
+  GraphicsUtil.drawPixelFont(number, self.assets.numberPixelFont, x, y, scale, scale, "center", 0)
 end
 
 function ClientStack:drawString(string, themePositionOffset, cameFromLegacyScoreOffset, fontSize)
@@ -215,7 +208,7 @@ function ClientStack:drawString(string, themePositionOffset, cameFromLegacyScore
   local limit = consts.CANVAS_WIDTH - x
   local alignment = "left"
   if themes[config.theme]:offsetsAreFixed() then
-    if self.which == 1 then
+    if self.renderIndex == 1 then
       limit = x
       x = 0
       alignment = "right"
@@ -232,33 +225,34 @@ end
 
 -- Positions the stack draw position for the given player
 function ClientStack:moveForRenderIndex(renderIndex)
-    -- Position of elements should ideally be on even coordinates to avoid non pixel alignment
-    if renderIndex == 1 then
-      self.mirror_x = 1
-      self.multiplication = 0
-    elseif renderIndex == 2 then
-      self.mirror_x = -1
-      self.multiplication = 1
-    end
-    local centerX = (GAME.globalCanvas:getWidth() / 2)
-    local stackWidth = self:canvasWidth()
-    local innerStackXMovement = 100
-    local outerStackXMovement = stackWidth + innerStackXMovement
-    self.panelOriginXOffset = 4
-    self.panelOriginYOffset = 4
+  self.renderIndex = renderIndex
+  -- Position of elements should ideally be on even coordinates to avoid non pixel alignment
+  if renderIndex == 1 then
+    self.mirror_x = 1
+    self.multiplication = 0
+  elseif renderIndex == 2 then
+    self.mirror_x = -1
+    self.multiplication = 1
+  end
+  local centerX = (GAME.globalCanvas:getWidth() / 2)
+  local stackWidth = self:canvasWidth()
+  local innerStackXMovement = 100
+  local outerStackXMovement = stackWidth + innerStackXMovement
+  self.panelOriginXOffset = 4
+  self.panelOriginYOffset = 4
 
-    local outerNonScaled = centerX - (outerStackXMovement * self.mirror_x)
-    self.origin_x = (self.panelOriginXOffset * self.mirror_x) + (outerNonScaled / self.gfxScale) -- The outer X value of the frame
+  local outerNonScaled = centerX - (outerStackXMovement * self.mirror_x)
+  self.origin_x = (self.panelOriginXOffset * self.mirror_x) + (outerNonScaled / self.gfxScale) -- The outer X value of the frame
 
-    local frameOriginNonScaled = outerNonScaled
-    if self.mirror_x == -1 then
-      frameOriginNonScaled = outerNonScaled - stackWidth
-    end
-    self.frameOriginX = frameOriginNonScaled / self.gfxScale -- The left X value where the frame is drawn
-    self.frameOriginY = 108 / self.gfxScale
+  local frameOriginNonScaled = outerNonScaled
+  if self.mirror_x == -1 then
+    frameOriginNonScaled = outerNonScaled - stackWidth
+  end
+  self.frameOriginX = frameOriginNonScaled / self.gfxScale -- The left X value where the frame is drawn
+  self.frameOriginY = 108 / self.gfxScale
 
-    self.panelOriginX = self.frameOriginX + self.panelOriginXOffset
-    self.panelOriginY = self.frameOriginY + self.panelOriginYOffset
+  self.panelOriginX = self.frameOriginX + self.panelOriginXOffset
+  self.panelOriginY = self.frameOriginY + self.panelOriginYOffset
 end
 
 -- to be used in conjunction with resetDrawArea
@@ -295,11 +289,11 @@ function ClientStack:drawCharacter()
     end
   end
 
-  self.character:drawPortrait(self.which, self.panelOriginXOffset, self.panelOriginYOffset, self.portraitFade, self.gfxScale)
+  self.character:drawPortrait(self.renderIndex, self.panelOriginXOffset, self.panelOriginYOffset, self.portraitFade, self.gfxScale)
 end
 
 function ClientStack:drawFrame()
-  local frameImage = themes[config.theme].images.frames[self.which]
+  local frameImage = self.assets.frame
 
   if frameImage then
     local scaleX = self:canvasWidth() / frameImage:getWidth()
@@ -309,7 +303,7 @@ function ClientStack:drawFrame()
 end
 
 function ClientStack:drawWall(displacement, rowCount)
-  local wallImage = themes[config.theme].images.walls[self.which]
+  local wallImage = self.assets.wall
 
   if wallImage then
     local y = (4 - displacement + rowCount * 16) * self.gfxScale
@@ -354,7 +348,7 @@ function ClientStack:drawAbsoluteMultibar(stop_time, shake_time, pre_stop_time)
   local barPos = themes[config.theme].multibar_Pos
   local overtimePos = themes[config.theme].multibar_LeftoverTime_Pos
 
-  self:drawLabel(themes[config.theme].images.healthbarFrames.absolute[self.which], framePos, themes[config.theme].healthbar_frame_Scale * (self.gfxScale / 3))
+  self:drawLabel(self.assets.multibar.frameAbsolute, framePos, themes[config.theme].healthbar_frame_Scale * (self.gfxScale / 3))
 
   local multiBarFrameCount = self.multiBarFrameCount
   local multiBarMaxHeight = 589 * (self.gfxScale / 3) * themes[config.theme].multibar_Scale
@@ -362,7 +356,7 @@ function ClientStack:drawAbsoluteMultibar(stop_time, shake_time, pre_stop_time)
 
   local healthHeight = (self.engine.health / multiBarFrameCount) * multiBarMaxHeight
   healthHeight = math.min(healthHeight, multiBarMaxHeight)
-  self:drawBar(themes[config.theme].images.IMG_healthbar, self.healthQuad, barPos, healthHeight, 0, 0, themes[config.theme].multibar_Scale)
+  self:drawBar(self.assets.multibar.health, self.healthQuad, barPos, healthHeight, 0, 0, themes[config.theme].multibar_Scale)
 
   bottomOffset = healthHeight
 
@@ -373,12 +367,12 @@ function ClientStack:drawAbsoluteMultibar(stop_time, shake_time, pre_stop_time)
     -- shake is only drawn if it is greater than prestop + stop
     -- shake is always guaranteed to fit
     local shakeHeight = (shake_time / multiBarFrameCount) * multiBarMaxHeight
-    self:drawBar(themes[config.theme].images.IMG_multibar_shake_bar, self.multi_shakeQuad, barPos, shakeHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
+    self:drawBar(self.assets.multibar.shake, self.multi_shakeQuad, barPos, shakeHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
   else
     -- stop/prestop are only drawn if greater than shake
     if stop_time > 0 then
       stopHeight = math.min(stop_time, multiBarFrameCount - self.engine.health) / multiBarFrameCount * multiBarMaxHeight
-      self:drawBar(themes[config.theme].images.IMG_multibar_stop_bar, self.multi_stopQuad, barPos, stopHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
+      self:drawBar(self.assets.multibar.stop, self.multi_stopQuad, barPos, stopHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
 
       bottomOffset = bottomOffset + stopHeight
     end
@@ -394,7 +388,7 @@ function ClientStack:drawAbsoluteMultibar(stop_time, shake_time, pre_stop_time)
     end
 
     if pre_stop_time and pre_stop_time > 0 then
-      self:drawBar(themes[config.theme].images.IMG_multibar_prestop_bar, self.multi_prestopQuad, barPos, preStopHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
+      self:drawBar(self.assets.multibar.preStop, self.multi_prestopQuad, barPos, preStopHeight, bottomOffset, 0, themes[config.theme].multibar_Scale)
     end
 
     if remainingSeconds > 0 then
@@ -409,7 +403,7 @@ function ClientStack:drawPlayerName()
 end
 
 function ClientStack:drawWinCount()
-  self:drawLabel(themes[config.theme].images.IMG_wins, themes[config.theme].winLabel_Pos, themes[config.theme].winLabel_Scale, true)
+  self:drawLabel(self.assets.wins, themes[config.theme].winLabel_Pos, themes[config.theme].winLabel_Scale, true)
   self:drawNumber(self.player:getWinCountForDisplay(), themes[config.theme].win_Pos, themes[config.theme].win_Scale, true)
 end
 
@@ -453,16 +447,33 @@ function ClientStack:game_ended()
   end
 end
 
+---@param assetPack IngameAssetPack
+function ClientStack:assignAssets(assetPack)
+  self.assets = assetPack
+
+  local width, height = self.assets.multibar.health:getDimensions()
+  self.healthQuad = GraphicsUtil:newRecycledQuad(0, 0, width, height, width, height)
+  width, height = self.assets.multibar.preStop:getDimensions()
+  self.multi_prestopQuad = GraphicsUtil:newRecycledQuad(0, 0, width, height, width, height)
+  width, height = self.assets.multibar.stop:getDimensions()
+  self.multi_stopQuad = GraphicsUtil:newRecycledQuad(0, 0, width, height, width, height)
+  width, height = self.assets.multibar.shake:getDimensions()
+  self.multi_shakeQuad = GraphicsUtil:newRecycledQuad(0, 0, width, height, width, height)
+end
+
+function ClientStack:deinit()
+  GraphicsUtil:releaseQuad(self.healthQuad)
+  GraphicsUtil:releaseQuad(self.multi_prestopQuad)
+  GraphicsUtil:releaseQuad(self.multi_stopQuad)
+  GraphicsUtil:releaseQuad(self.multi_shakeQuad)
+end
+
 --------------------------------
 ------ abstract functions ------
 --------------------------------
 
 function ClientStack:runGameOver()
   error("did not implement runGameOver")
-end
-
-function ClientStack:deinit()
-  error("did not implement deinit")
 end
 
 function ClientStack:render()

--- a/client/src/ClientStack.lua
+++ b/client/src/ClientStack.lua
@@ -253,6 +253,8 @@ function ClientStack:moveForRenderIndex(renderIndex)
 
   self.panelOriginX = self.frameOriginX + self.panelOriginXOffset
   self.panelOriginY = self.frameOriginY + self.panelOriginYOffset
+
+  self:assignAssets(GAME.theme:getIngameAssetPack(self.renderIndex))
 end
 
 -- to be used in conjunction with resetDrawArea

--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -191,6 +191,15 @@ function Game:writeReleaseStreamDefinition()
             prefix = "panel-beta-"
           }
         },
+        {
+          name = "engine-preview",
+          versioningType = "timestamp",
+          serverEndPoint = {
+            type = "filesystem",
+            url = "https://panelattack.com/downloads/updates/engine-preview",
+            prefix = "panel-"
+          }
+        }
       },
       default = "stable"
     }

--- a/client/src/Player.lua
+++ b/client/src/Player.lua
@@ -410,7 +410,7 @@ function Player:getInfo()
   info.wantsReady = tostring(self.settings.wantsReady)
   info.wantsRanked = tostring(self.settings.wantsRanked)
   info.inputMethod = self.settings.inputMethod
-  --info.publicId = self.settings.publicId
+  info.publicId = self.publicId
   info.playerNumber = self.playerNumber
   info.isLocal = tostring(self.isLocal)
   info.human = tostring(self.human)

--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -36,7 +36,6 @@ function(self, args)
   ---@class PlayerStack
   self = self
   self.player = args.player
-  args.which = self.which
   self.stackInteraction = args.stackInteraction
 
   self.engine = EngineStack(args)
@@ -309,10 +308,7 @@ end
 -- Consider recycling any memory that might leave around a lot of garbage.
 -- Note: You can just leave the variables to clear / garbage collect on their own if they aren't large.
 function PlayerStack:deinit()
-  GraphicsUtil:releaseQuad(self.healthQuad)
-  GraphicsUtil:releaseQuad(self.multi_prestopQuad)
-  GraphicsUtil:releaseQuad(self.multi_stopQuad)
-  GraphicsUtil:releaseQuad(self.multi_shakeQuad)
+  ClientStack.deinit(self)
   self.engine:deinit()
 end
 
@@ -842,16 +838,16 @@ function PlayerStack:drawDebug()
     GraphicsUtil.printf("riselock " .. tostring(engine.rise_lock), drawX, drawY)
 
     -- drawY = drawY + padding
-    -- GraphicsUtil.printf("P" .. stack.which .." Panels: " .. stack.panel_buffer, drawX, drawY)
+    -- GraphicsUtil.printf("P" .. engine.which .." Panels: " .. stack.panel_buffer, drawX, drawY)
 
     drawY = drawY + padding
     GraphicsUtil.printf("P" .. engine.which .." Ended?: " .. tostring(engine:game_ended()), drawX, drawY)
 
     -- drawY = drawY + padding
-    -- GraphicsUtil.printf("P" .. stack.which .." attacks: " .. #stack.telegraph.attacks, drawX, drawY)
+    -- GraphicsUtil.printf("P" .. engine.which .." attacks: " .. #stack.telegraph.attacks, drawX, drawY)
 
     -- drawY = drawY + padding
-    -- GraphicsUtil.printf("P" .. stack.which .." Garbage Q: " .. stack.incomingGarbage:len(), drawX, drawY)
+    -- GraphicsUtil.printf("P" .. engine.which .." Garbage Q: " .. stack.incomingGarbage:len(), drawX, drawY)
   end
 end
 
@@ -952,7 +948,7 @@ function PlayerStack:drawRating()
   end
 
   if rating then
-    self:drawLabel(self.theme.images["IMG_rating_" .. self.which .. "P"], self.theme.ratingLabel_Pos, self.theme.ratingLabel_Scale, true)
+    self:drawLabel(self.assets.rating, self.theme.ratingLabel_Pos, self.theme.ratingLabel_Scale, true)
     self:drawNumber(rating, self.theme.rating_Pos, self.theme.rating_Scale, true)
   end
 end
@@ -1011,14 +1007,14 @@ end
 
 function PlayerStack:drawRelativeMultibar(stop_time, shake_time)
   local engine = self.engine
-  self:drawLabel(self.theme.images.healthbarFrames.relative[self.which], self.theme.healthbar_frame_Pos, self.theme.healthbar_frame_Scale)
+  self:drawLabel(self.assets.multibar.frameRelative, self.theme.healthbar_frame_Pos, self.theme.healthbar_frame_Scale)
 
   -- Healthbar
-  local healthbar = engine.health * (self.theme.images.IMG_healthbar:getHeight() / engine.levelData.maxHealth)
-  self.healthQuad:setViewport(0, self.theme.images.IMG_healthbar:getHeight() - healthbar, self.theme.images.IMG_healthbar:getWidth(), healthbar)
+  local healthbar = engine.health * (self.assets.multibar.health:getHeight() / engine.levelData.maxHealth)
+  self.healthQuad:setViewport(0, self.assets.multibar.health:getHeight() - healthbar, self.assets.multibar.health:getWidth(), healthbar)
   local x = self:elementOriginXWithOffset(self.theme.healthbar_Pos, false) / self.gfxScale
-  local y = self:elementOriginYWithOffset(self.theme.healthbar_Pos, false) + (self.theme.images.IMG_healthbar:getHeight() - healthbar) / self.gfxScale
-  drawQuadGfxScaled(self, self.theme.images.IMG_healthbar, self.healthQuad, x, y, self.theme.healthbar_Rotate, self.theme.healthbar_Scale, self.theme.healthbar_Scale, 0, 0, self.multiplication)
+  local y = self:elementOriginYWithOffset(self.theme.healthbar_Pos, false) + (self.assets.multibar.health:getHeight() - healthbar) / self.gfxScale
+  drawQuadGfxScaled(self, self.assets.multibar.health, self.healthQuad, x, y, self.theme.healthbar_Rotate, self.theme.healthbar_Scale, self.theme.healthbar_Scale, 0, 0, self.multiplication)
 
   -- Prestop bar
   if engine.pre_stop_time == 0 or self.maxPrestop == nil then
@@ -1040,51 +1036,51 @@ function PlayerStack:drawRelativeMultibar(stop_time, shake_time)
 
   local multi_shake_bar, multi_stop_bar, multi_prestop_bar = 0, 0, 0
   if engine.peak_shake_time > 0 and shake_time >= engine.pre_stop_time + stop_time then
-    multi_shake_bar = shake_time * (self.theme.images.IMG_multibar_shake_bar:getHeight() / engine.peak_shake_time) * 3
+    multi_shake_bar = shake_time * (self.assets.multibar.shake:getHeight() / engine.peak_shake_time) * 3
   end
   if self.maxStop > 0 and shake_time < engine.pre_stop_time + stop_time then
-    multi_stop_bar = stop_time * (self.theme.images.IMG_multibar_stop_bar:getHeight() / self.maxStop) * 1.5
+    multi_stop_bar = stop_time * (self.assets.multibar.stop:getHeight() / self.maxStop) * 1.5
   end
   if self.maxPrestop > 0 and shake_time < engine.pre_stop_time + stop_time then
-    multi_prestop_bar = engine.pre_stop_time * (self.theme.images.IMG_multibar_prestop_bar:getHeight() / self.maxPrestop) * 1.5
+    multi_prestop_bar = engine.pre_stop_time * (self.assets.multibar.preStop:getHeight() / self.maxPrestop) * 1.5
   end
-  self.multi_shakeQuad:setViewport(0, self.theme.images.IMG_multibar_shake_bar:getHeight() - multi_shake_bar, self.theme.images.IMG_multibar_shake_bar:getWidth(), multi_shake_bar)
-  self.multi_stopQuad:setViewport(0, self.theme.images.IMG_multibar_stop_bar:getHeight() - multi_stop_bar, self.theme.images.IMG_multibar_stop_bar:getWidth(), multi_stop_bar)
-  self.multi_prestopQuad:setViewport(0, self.theme.images.IMG_multibar_prestop_bar:getHeight() - multi_prestop_bar, self.theme.images.IMG_multibar_prestop_bar:getWidth(), multi_prestop_bar)
+  self.multi_shakeQuad:setViewport(0, self.assets.multibar.shake:getHeight() - multi_shake_bar, self.assets.multibar.shake:getWidth(), multi_shake_bar)
+  self.multi_stopQuad:setViewport(0, self.assets.multibar.stop:getHeight() - multi_stop_bar, self.assets.multibar.stop:getWidth(), multi_stop_bar)
+  self.multi_prestopQuad:setViewport(0, self.assets.multibar.preStop:getHeight() - multi_prestop_bar, self.assets.multibar.preStop:getWidth(), multi_prestop_bar)
 
   --Shake
   x = self:elementOriginXWithOffset(self.theme.multibar_Pos, false)
   y = self:elementOriginYWithOffset(self.theme.multibar_Pos, false)
-  if self.theme.images.IMG_multibar_shake_bar then
-    GraphicsUtil.drawQuad(self.theme.images.IMG_multibar_shake_bar, self.multi_shakeQuad, x, y + self.theme.images.IMG_multibar_shake_bar:getHeight() - multi_shake_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
+  if self.assets.multibar.shake then
+    GraphicsUtil.drawQuad(self.assets.multibar.shake, self.multi_shakeQuad, x, y + self.assets.multibar.shake:getHeight() - multi_shake_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
   end
   --Stop
-  if self.theme.images.IMG_multibar_stop_bar then
-    GraphicsUtil.drawQuad(self.theme.images.IMG_multibar_stop_bar, self.multi_stopQuad, x, y - multi_shake_bar + self.theme.images.IMG_multibar_stop_bar:getHeight() - multi_stop_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
+  if self.assets.multibar.stop then
+    GraphicsUtil.drawQuad(self.assets.multibar.stop, self.multi_stopQuad, x, y - multi_shake_bar + self.assets.multibar.stop:getHeight() - multi_stop_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
   end
   -- Prestop
-  if self.theme.images.IMG_multibar_prestop_bar then
-    GraphicsUtil.drawQuad(self.theme.images.IMG_multibar_prestop_bar, self.multi_prestopQuad, x, y - multi_shake_bar + multi_stop_bar + self.theme.images.IMG_multibar_prestop_bar:getHeight() - multi_prestop_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
+  if self.assets.multibar.preStop then
+    GraphicsUtil.drawQuad(self.assets.multibar.preStop, self.multi_prestopQuad, x, y - multi_shake_bar + multi_stop_bar + self.assets.multibar.preStop:getHeight() - multi_prestop_bar, 0, self.theme.multibar_Scale, self.theme.multibar_Scale, 0, 0, self.multiplication)
   end
 end
 
 function PlayerStack:drawScore()
-  self:drawLabel(self.theme.images["IMG_score_" .. self.which .. "P"], self.theme.scoreLabel_Pos, self.theme.scoreLabel_Scale)
+  self:drawLabel(self.assets.score, self.theme.scoreLabel_Pos, self.theme.scoreLabel_Scale)
   self:drawNumber(self.engine.score, self.theme.score_Pos, self.theme.score_Scale)
 end
 
 function PlayerStack:drawSpeed()
-  self:drawLabel(self.theme.images["IMG_speed_" .. self.which .. "P"], self.theme.speedLabel_Pos, self.theme.speedLabel_Scale)
+  self:drawLabel(self.assets.speed, self.theme.speedLabel_Pos, self.theme.speedLabel_Scale)
   self:drawNumber(self.engine.speed, self.theme.speed_Pos, self.theme.speed_Scale)
 end
 
 function PlayerStack:drawLevel()
   if self.level then
-    self:drawLabel(self.theme.images["IMG_level_" .. self.which .. "P"], self.theme.levelLabel_Pos, self.theme.levelLabel_Scale)
+    self:drawLabel(self.assets.level, self.theme.levelLabel_Pos, self.theme.levelLabel_Scale)
 
     local x = self:elementOriginXWithOffset(self.theme.level_Pos, false)
     local y = self:elementOriginYWithOffset(self.theme.level_Pos, false)
-    local levelAtlas = self.theme.images.levelNumberAtlas[self.which]
+    local levelAtlas = self.assets.levelAtlas
     GraphicsUtil.drawQuad(levelAtlas.image, levelAtlas.quads[self.level], x, y, 0, 28 / levelAtlas.charWidth * self.theme.level_Scale, 26 / levelAtlas.charHeight * self.theme.level_Scale, 0, 0, self.multiplication)
   end
 end
@@ -1100,7 +1096,7 @@ function PlayerStack:drawAnalyticData()
   local width = 160
   local height = 600
   local x = paddingToAnalytics + backgroundPadding
-  if self.which == 2 then
+  if self.renderIndex == 2 then
     x = consts.CANVAS_WIDTH - paddingToAnalytics - width + backgroundPadding
   end
   local y = self.frameOriginY * self.gfxScale + backgroundPadding
@@ -1213,7 +1209,7 @@ end
 function PlayerStack:drawMoveCount()
   -- draw outside of stack's frame canvas
   if self.engine.puzzle then
-    self:drawLabel(themes[config.theme].images.IMG_moves, themes[config.theme].moveLabel_Pos, themes[config.theme].moveLabel_Scale, false, true)
+    self:drawLabel(self.assets.moves, themes[config.theme].moveLabel_Pos, themes[config.theme].moveLabel_Scale, false, true)
     local moveNumber = math.abs(self.engine.puzzle.remaining_moves)
     if self.engine.puzzle.puzzleType == "moves" then
       moveNumber = self.engine.puzzle.remaining_moves

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -10,6 +10,8 @@ local tableUtils = require("common.lib.tableUtils")
 local SoundController = require("client.src.music.SoundController")
 local UpdatingImage = require("client.src.graphics.UpdatingImage")
 
+local MAX_SUPPORTED_PLAYERS = 2
+
 -- from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 local flags = {
   "cn", -- China
@@ -325,8 +327,6 @@ function Theme:loadMenuGraphics()
   self.images.IMG_bug = self:load_theme_img("bug")
 end
 
-local MAX_SUPPORTED_PLAYERS = 2
-
 ---@param theme Theme
 ---@return table<integer, love.Texture[]>
 local function loadGridCursors(theme)
@@ -420,7 +420,7 @@ function Theme:loadIngameGraphics()
   --play field frames, plus the wall at the bottom.
   self.images.frames = {}
   self.images.walls = {}
-  for i = 1, 2 do
+  for i = 1, MAX_SUPPORTED_PLAYERS do
     self.images.frames[i] = self:load_theme_img("frame/frame" .. i .. "P")
     self.images.walls[i] = self:load_theme_img("frame/wall" .. i .. "P")
   end
@@ -443,7 +443,7 @@ function Theme:loadIngameLabels()
   self.images.levelLabels = {}
   self.images.scoreLabels = {}
   self.images.ratingLabels = {}
-  for i = 1, 2 do
+  for i = 1, MAX_SUPPORTED_PLAYERS do
     self.images.speedLabels[i] = self:load_theme_img("speed_" .. i .. "P")
     self.images.levelLabels[i] = self:load_theme_img("level_" .. i .. "P")
     self.images.scoreLabels[i] = self:load_theme_img("score_" .. i .. "P")
@@ -465,11 +465,11 @@ end
 function Theme:loadMultibar()
   self.images.healthbarFrames = {}
   self.images.healthbarFrames.relative = {}
-  self.images.healthbarFrames.relative[1]  = self:load_theme_img("healthbar_frame_1P")
-  self.images.healthbarFrames.relative[2]  = self:load_theme_img("healthbar_frame_2P")
   self.images.healthbarFrames.absolute = {}
-  self.images.healthbarFrames.absolute[1] = self:load_theme_img("healthbar_frame_1P_absolute")
-  self.images.healthbarFrames.absolute[2] = self:load_theme_img("healthbar_frame_2P_absolute")
+  for i = 1, MAX_SUPPORTED_PLAYERS do
+    self.images.healthbarFrames.relative[i]  = self:load_theme_img("healthbar_frame_" .. i .. "P")
+    self.images.healthbarFrames.absolute[i] = self:load_theme_img("healthbar_frame_" .. i .. "P_absolute")
+  end
 
   self.images.IMG_healthbar = self:load_theme_img("healthbar")
 
@@ -523,7 +523,7 @@ end
 function Theme:loadLevelNumberAtlasses()
   self.images.levelNumberAtlas = {}
   local levels = 11
-  for i = 1, 2 do
+  for i = 1, MAX_SUPPORTED_PLAYERS do
     self.images.levelNumberAtlas[i] = {}
     self.images.levelNumberAtlas[i].image = self:load_theme_img("level_numbers_" .. i .. "P")
     local charWidth = self.images.levelNumberAtlas[i].image:getWidth() / levels

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -30,7 +30,7 @@ local flags = {
 ---@field name string
 ---@field version ThemeVersion
 ---@field images table
----@field fontMaps table
+---@field fontMaps table<string, PixelFontMap | PixelFontMap[]>
 ---@field sounds table<string, (love.Source | table | nil)>
 ---@field musics table<string, Music>
 ---@field font table
@@ -282,16 +282,20 @@ function Theme:loadDefaultConfig()
 end
 
 Theme.themeDirectoryPath = THEME_DIRECTORY_PATH or "themes/"
-Theme.defaultThemeDirectoryPath = "client/assets/themes/" .. consts.DEFAULT_THEME_DIRECTORY .. "/"
+Theme.defaultThemeDirectoryPath = "client/assets/themes/" .. consts.DEFAULT_THEME_DIRECTORY
 
 -- loads the image of the given name
+---@param name string
+---@param useBackup boolean?
+---@return love.Texture
 function Theme:load_theme_img(name, useBackup)
   if useBackup == nil then
     useBackup = true
   end
   local img = GraphicsUtil.loadImageFromSupportedExtensions(self.path .. "/" .. name)
   if not img and useBackup then
-    img = GraphicsUtil.loadImageFromSupportedExtensions(Theme.defaultThemeDirectoryPath .. name)
+    img = GraphicsUtil.loadImageFromSupportedExtensions(Theme.defaultThemeDirectoryPath .. "/".. name)
+    ---@cast img -nil # this is not strictly true but the default should always be able to provide a backup
   end
   return img
 end
@@ -324,20 +328,32 @@ end
 local MAX_SUPPORTED_PLAYERS = 2
 
 ---@param theme Theme
----@return table<integer, table<integer, love.Texture>>
+---@return table<integer, love.Texture[]>
 local function loadGridCursors(theme)
   local gridCursors = {}
   theme.images.IMG_char_sel_cursors = {}
-  for player_num = 1, MAX_SUPPORTED_PLAYERS do
-    gridCursors[player_num] = {}
+  for playerNumber = 1, MAX_SUPPORTED_PLAYERS do
+    gridCursors[playerNumber] = {}
     for position_num = 1, 2 do
-      gridCursors[player_num][position_num] = theme:load_theme_img("p" .. player_num .. "_select_screen_cursor" .. position_num)
+      gridCursors[playerNumber][position_num] = theme:load_theme_img("p" .. playerNumber .. "_select_screen_cursor" .. position_num)
     end
   end
 
   theme.images.IMG_char_sel_cursors = gridCursors
 
   return theme.images.IMG_char_sel_cursors
+end
+
+---@return love.Texture[]
+local function loadPlayerNumberIcons(theme)
+  local icons = {}
+  for playerNumber = 1, MAX_SUPPORTED_PLAYERS do
+    icons[playerNumber] = theme:load_theme_img("p" .. playerNumber)
+  end
+
+  theme.images.IMG_players = icons
+
+  return theme.images.IMG_players
 end
 
 function Theme:loadSelectionGraphics()
@@ -372,11 +388,7 @@ function Theme:loadSelectionGraphics()
   self.images.IMG_random_stage = self:load_theme_img("random_stage")
   self.images.IMG_random_character = self:load_theme_img("random_character")
 
-  self.images.IMG_players = {}
-  for player_num = 1, MAX_SUPPORTED_PLAYERS do
-    self.images.IMG_players[player_num] = self:load_theme_img("p" .. player_num)
-  end
-
+  loadPlayerNumberIcons(self)
   loadGridCursors(self)
 end
 
@@ -408,10 +420,10 @@ function Theme:loadIngameGraphics()
   --play field frames, plus the wall at the bottom.
   self.images.frames = {}
   self.images.walls = {}
-  self.images.frames[1] = self:load_theme_img("frame/frame1P")
-  self.images.frames[2] = self:load_theme_img("frame/frame2P")
-  self.images.walls[1] = self:load_theme_img("frame/wall1P")
-  self.images.walls[2] = self:load_theme_img("frame/wall2P")
+  for i = 1, 2 do
+    self.images.frames[i] = self:load_theme_img("frame/frame" .. i .. "P")
+    self.images.walls[i] = self:load_theme_img("frame/wall" .. i .. "P")
+  end
 
   self:loadIngameLabels()
   self:loadMultibar()
@@ -421,39 +433,33 @@ function Theme:loadIngameGraphics()
 end
 
 function Theme:loadIngameLabels()
-  local numberAtlasCharacters = "0123456789"
-  local numberAtlas1 = self:load_theme_img("numbers_1P")
-  local numberAtlas2 = self:load_theme_img("numbers_2P")
-  self.fontMaps.numbers = {}
-  self.fontMaps.numbers[1] = GraphicsUtil.createPixelFontMap(numberAtlasCharacters, numberAtlas1)
-  self.fontMaps.numbers[2] = GraphicsUtil.createPixelFontMap(numberAtlasCharacters, numberAtlas2)
-
-  self.images.IMG_time = self:load_theme_img("time")
-
   local timeAtlasCharacters = "0123456789:'"
   local timeAtlas = self:load_theme_img("time_numbers")
   self.fontMaps.time = GraphicsUtil.createPixelFontMap(timeAtlasCharacters, timeAtlas)
 
+  local numberAtlasCharacters = "0123456789"
+  self.fontMaps.numbers = {}
+  self.images.speedLabels = {}
+  self.images.levelLabels = {}
+  self.images.scoreLabels = {}
+  self.images.ratingLabels = {}
+  for i = 1, 2 do
+    self.images.speedLabels[i] = self:load_theme_img("speed_" .. i .. "P")
+    self.images.levelLabels[i] = self:load_theme_img("level_" .. i .. "P")
+    self.images.scoreLabels[i] = self:load_theme_img("score_" .. i .. "P")
+    self.images.ratingLabels[i] = self:load_theme_img("rating_" .. i .. "P")
+    local numberAtlas = self:load_theme_img("numbers_" .. i .. "P")
+    self.fontMaps.numbers[i] = GraphicsUtil.createPixelFontMap(numberAtlasCharacters, numberAtlas)
+  end
+
+  self.images.IMG_time = self:load_theme_img("time")
   self.images.IMG_moves = self:load_theme_img("moves")
-
-  self.images.IMG_score_1P = self:load_theme_img("score_1P")
-  self.images.IMG_score_2P = self:load_theme_img("score_2P")
-
-  self.images.IMG_speed_1P = self:load_theme_img("speed_1P")
-  self.images.IMG_speed_2P = self:load_theme_img("speed_2P")
-
-  self.images.IMG_level_1P = self:load_theme_img("level_1P")
-  self.images.IMG_level_2P = self:load_theme_img("level_2P")
-
   self.images.IMG_wins = self:load_theme_img("wins")
-
-  self:loadLevelNumberAtlasses()
 
   self.images.IMG_casual = self:load_theme_img("casual")
   self.images.IMG_ranked = self:load_theme_img("ranked")
 
-  self.images.IMG_rating_1P = self:load_theme_img("rating_1P")
-  self.images.IMG_rating_2P = self:load_theme_img("rating_2P")
+  self:loadLevelNumberAtlasses()
 end
 
 function Theme:loadMultibar()
@@ -513,14 +519,13 @@ function Theme:loadCards()
   end
 end
 
+-- effectively these are the same as PixelFontMaps, convert them?
 function Theme:loadLevelNumberAtlasses()
   self.images.levelNumberAtlas = {}
-  self.images.levelNumberAtlas[1] = {}
-  self.images.levelNumberAtlas[1].image = self:load_theme_img("level_numbers_1P")
-  self.images.levelNumberAtlas[2] = {}
-  self.images.levelNumberAtlas[2].image = self:load_theme_img("level_numbers_2P")
   local levels = 11
-  for i = 1, #self.images.levelNumberAtlas do
+  for i = 1, 2 do
+    self.images.levelNumberAtlas[i] = {}
+    self.images.levelNumberAtlas[i].image = self:load_theme_img("level_numbers_" .. i .. "P")
     local charWidth = self.images.levelNumberAtlas[i].image:getWidth() / levels
     local charHeight = self.images.levelNumberAtlas[i].image:getHeight()
     local quads = {}
@@ -591,16 +596,15 @@ function Theme:deinitializeGraphics()
       -- numbers have 1 more level of nesting so make a union of that and set it to fontMap
       local f = {}
       for i = 1, #fontMap do
-        for _, value in pairs(fontMap[i]) do
+        for _, value in pairs(fontMap.charToQuad[i]) do
           f[#f + 1] = value
         end
       end
       fontMap = f
     end
 
-    for symbol, value in pairs(fontMap) do
-      if tostring(symbol):len() == 1 and type(value) == "userdata" and value:typeOf("Quad") then
-        -- userdata means this is a love object which in turn means we can safely use typeOf to confirm it's a quad
+    for _, value in pairs(fontMap.charToQuad) do
+      if value:typeOf("Quad") then
         GraphicsUtil:releaseQuad(value)
       end
     end
@@ -632,7 +636,7 @@ end
 local function loadThemeSfx(theme, SFX_name)
   local dirs_to_check = {
     theme.path .. "/sfx/",
-    Theme.defaultThemeDirectoryPath .. "sfx/"
+    Theme.defaultThemeDirectoryPath .. "/sfx/"
   }
   return fileUtils.findSound(SFX_name, dirs_to_check)
 end
@@ -885,13 +889,212 @@ function Theme:playMoveSfx()
   SoundController:playSfx(self.sounds.menu_move)
 end
 
+---@param index integer?
+---@return love.Texture[]
 function Theme:getGridCursor(index)
   index = index or 1
-  if not self.images.IMG_char_sel_cursors or self.images.IMG_char_sel_cursors[index] then
+  if not (self.images.IMG_char_sel_cursors and self.images.IMG_char_sel_cursors[index]) then
     loadGridCursors(self)
   end
 
   return self.images.IMG_char_sel_cursors[index]
+end
+
+---@return love.Texture
+function Theme:getWinsLabel()
+  index = index or 1
+  if not self.images.IMG_wins then
+    self:loadIngameLabels()
+  end
+
+  return self.images.IMG_wins
+end
+
+---@return love.Texture
+function Theme:getMovesLabel()
+  index = index or 1
+  if not self.images.IMG_moves then
+    self:loadIngameLabels()
+  end
+
+  return self.images.IMG_moves
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getSpeedLabel(index)
+  index = index or 1
+  if not (self.images.speedLabels and self.images.speedLabels[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.images.speedLabels[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getRatingLabel(index)
+  index = index or 1
+  if not (self.images.ratingLabels and self.images.ratingLabels[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.images.ratingLabels[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getLevelLabel(index)
+  index = index or 1
+  if not (self.images.levelLabels and self.images.levelLabels[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.images.levelLabels[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getScoreLabel(index)
+  index = index or 1
+  if not (self.images.scoreLabels and self.images.scoreLabels[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.images.scoreLabels[index]
+end
+
+---@param index integer?
+---@return PixelFontMap
+function Theme:getNumberPixelFont(index)
+  index = index or 1
+  if not (self.fontMaps.numbers and self.fontMaps.numbers[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.fontMaps.numbers[index]
+end
+
+---@param index integer?
+---@return {image: love.Texture, charWidth: integer, charHeight: integer, quads: love.Quad[]}
+function Theme:getLevelAtlas(index)
+  index = index or 1
+  if not (self.images.levelNumberAtlas and self.images.levelNumberAtlas[index]) then
+    self:loadIngameLabels()
+  end
+
+  return self.images.levelNumberAtlas[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getFrame(index)
+  index = index or 1
+  if not (self.images.frames and self.images.frames[index]) then
+    self:loadIngameGraphics()
+  end
+
+  return self.images.frames[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getWall(index)
+  index = index or 1
+  if not (self.images.walls and self.images.walls[index]) then
+    self:loadIngameGraphics()
+  end
+
+  return self.images.walls[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getPlayerNumberIcon(index)
+  index = index or 1
+  if not (self.images.IMG_players and self.images.IMG_players[index]) then
+    loadPlayerNumberIcons(self)
+  end
+
+  return self.images.IMG_players[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getHealthBarFrameAbsolute(index)
+  index = index or 1
+  if not (self.images.healthbarFrames and self.images.healthbarFrames.absolute and self.images.healthbarFrames.absolute[index]) then
+    self:loadMultibar()
+  end
+
+  return self.images.healthbarFrames.absolute[index]
+end
+
+---@param index integer?
+---@return love.Texture
+function Theme:getHealthBarFrameRelative(index)
+  index = index or 1
+  if not (self.images.healthbarFrames and self.images.healthbarFrames.relative and self.images.healthbarFrames.relative[index]) then
+    self:loadMultibar()
+  end
+
+  return self.images.healthbarFrames.relative[index]
+end
+
+---@param index integer
+---@return MultiBarPack
+function Theme:getMultibar(index)
+  ---@class MultiBarPack
+  local multibar = {
+    frameAbsolute = self:getHealthBarFrameAbsolute(index),
+    frameRelative = self:getHealthBarFrameRelative(index),
+    health = self.images.IMG_healthbar,
+    preStop = self.images.IMG_multibar_prestop_bar,
+    stop = self.images.IMG_multibar_stop_bar,
+    shake = self.images.IMG_multibar_shake_bar,
+  }
+
+  return multibar
+end
+
+---@return PixelFontMap
+function Theme:getTimePixelFont()
+  index = index or 1
+  if not self.fontMaps.time then
+    self:loadIngameLabels()
+  end
+
+  return self.fontMaps.time
+end
+
+---@param index integer
+---@return IngameAssetPack
+function Theme:getIngameAssetPack(index)
+  ---@class IngameAssetPack
+  local pack = {
+    speed = self:getSpeedLabel(index),
+    score = self:getScoreLabel(index),
+    rating = self:getRatingLabel(index),
+    level = self:getLevelLabel(index),
+    levelAtlas = self:getLevelAtlas(index),
+    numberPixelFont = self:getNumberPixelFont(index),
+    frame = self:getFrame(index),
+    wall = self:getWall(index),
+    multibar = self:getMultibar(index),
+    wins = self:getWinsLabel(),
+    moves = self:getMovesLabel(),
+  }
+
+  return pack
+end
+
+function Theme:getSelectionAssetPack(index)
+  local pack = {
+    playerNumberIcon = self:getPlayerNumberIcon(index),
+    gridCursor = self:getGridCursor(index),
+  }
+
+  return pack
 end
 
 return Theme

--- a/client/src/network/NetClient.lua
+++ b/client/src/network/NetClient.lua
@@ -250,12 +250,7 @@ local function processInputMessages(self)
   if self.room and self.room.match then
     for _, msg in ipairs(messages) do
       for type, data in pairs(msg) do
-        logger.trace("Processing: " .. type .. " with data:" .. data)
-        if type == NetworkProtocol.serverMessageTypes.secondOpponentInput.prefix then
-          self.room.match.stacks[1]:receiveConfirmedInput(data)
-        elseif type == NetworkProtocol.serverMessageTypes.opponentInput.prefix then
-          self.room.match.stacks[2]:receiveConfirmedInput(data)
-        end
+        self.room.match:receiveInput(type, data)
       end
     end
   end

--- a/client/src/scenes/CharacterSelect.lua
+++ b/client/src/scenes/CharacterSelect.lua
@@ -9,6 +9,9 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 local Character = require("client.src.mods.Character")
 
 -- The character select screen scene
+---@class CharacterSelect : Scene
+---@field backgroundImg table
+---@field players Player[]
 local CharacterSelect = class(function(self)
   self.backgroundImg = themes[config.theme].images.bg_select_screen
   self.music = "select_screen"
@@ -34,6 +37,16 @@ end
 -- end abstract functions
 
 function CharacterSelect:load()
+  self.players = shallowcpy(GAME.battleRoom.players)
+  -- display order is driven by locality
+  table.sort(self.players, function(a, b)
+    if a.isLocal == b.isLocal then
+      return a.playerNumber < b.playerNumber
+    else
+      return a.isLocal
+    end
+  end)
+
   self.ui = {}
   self.ui.cursors = {}
   self.ui.characterIcons = {}
@@ -41,6 +54,8 @@ function CharacterSelect:load()
   self:customLoad()
 end
 
+---@param player Player
+---@return UiElement playerIcon
 function CharacterSelect:createPlayerIcon(player)
   local playerIcon = ui.UiElement({hFill = true, vFill = true})
 
@@ -79,7 +94,7 @@ function CharacterSelect:createPlayerIcon(player)
   end
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
@@ -134,6 +149,7 @@ function CharacterSelect:createPlayerIcon(player)
   return playerIcon
 end
 
+---@return TextButton readyButton
 function CharacterSelect:createReadyButton()
   local readyButton = ui.TextButton({
     hFill = true,
@@ -158,6 +174,7 @@ function CharacterSelect:createReadyButton()
   return readyButton
 end
 
+---@return TextButton leaveButton
 function CharacterSelect:createLeaveButton()
   leaveButton = ui.TextButton({
     hFill = true,
@@ -175,6 +192,9 @@ function CharacterSelect:createLeaveButton()
   return leaveButton
 end
 
+---@param player Player
+---@param width number
+---@return UiElement stageCarousel
 function CharacterSelect:createStageCarousel(player, width)
   local stageCarousel = ui.StageCarousel({hAlign = "center", vAlign = "center", width = width, vFill = true})
   stageCarousel:loadCurrentStages()
@@ -194,13 +214,13 @@ function CharacterSelect:createStageCarousel(player, width)
   player:connectSignal("selectedStageIdChanged", stageCarousel, stageCarousel.setPassengerById)
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     scale = 2,
   })
 
-  if #GAME.battleRoom.players > 1 then
+  if #self.players > 1 then
     playerNumberIcon.hAlign = "center"
     playerNumberIcon.vAlign = "top"
     playerNumberIcon.y = 2
@@ -230,6 +250,7 @@ local super_select_pixelcode = [[
       }
   ]]
 
+---@return Button[] characterButtons
 function CharacterSelect:getCharacterButtons()
   local characterButtons = {}
 
@@ -287,7 +308,7 @@ function CharacterSelect:getCharacterButtons()
       local player
       if inputSource and inputSource.player then
         player = inputSource.player
-      elseif tableUtils.trueForAny(GAME.battleRoom.players, function(p) return p == GAME.localPlayer end) then
+      elseif tableUtils.trueForAny(self.players, function(p) return p == GAME.localPlayer end) then
          player = GAME.localPlayer
       else
         return
@@ -336,6 +357,7 @@ local function updateSuperSelectShader(image, timer)
   end
 end
 
+---@param characterButton Button
 function CharacterSelect.applySuperSelectInteraction(characterButton)
   -- creating the super select image + shader
   local superSelectImage = ui.ImageContainer({image = themes[config.theme].images.IMG_super, hFill = true, vFill = true, hAlign = "center", vAlign = "center"})
@@ -430,7 +452,7 @@ function CharacterSelect:createCursor(grid, player)
     startPosition = {x = 9, y = 2},
     player = player,
     -- this needs to be index, not playerNumber, as playerNumber is a server prop
-    frameImages = themes[config.theme]:getGridCursor(tableUtils.indexOf(GAME.battleRoom.players, player)),
+    frameImages = themes[config.theme]:getGridCursor(tableUtils.indexOf(self.players, player)),
   })
 
   player:connectSignal("wantsReadyChanged", cursor, cursor.setRapidBlinking)
@@ -478,7 +500,7 @@ function CharacterSelect:createPanelCarousel(player, height)
   player:connectSignal("colorCountChanged", panelCarousel, panelCarousel.setColorCount)
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
@@ -493,6 +515,10 @@ function CharacterSelect:createPanelCarousel(player, height)
   return panelCarousel
 end
 
+---@param player Player
+---@param imageWidth number
+---@param height number
+---@return UiElement levelSliderContainer
 function CharacterSelect:createLevelSlider(player, imageWidth, height)
   local levelSlider = ui.LevelSlider({
     tickLength = imageWidth,
@@ -562,7 +588,7 @@ function CharacterSelect:createLevelSlider(player, imageWidth, height)
   player:connectSignal("levelChanged", levelSlider, levelSlider.setValue)
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
@@ -577,6 +603,9 @@ function CharacterSelect:createLevelSlider(player, imageWidth, height)
   return uiElement
 end
 
+---@param player Player
+---@param width number
+---@return BoolSelector rankedSelector
 function CharacterSelect:createRankedSelection(player, width)
   local rankedSelector = ui.BoolSelector({startValue = player.settings.wantsRanked, vFill = true, width = width, vAlign = "center", hAlign = "center"})
   rankedSelector.onValueChange = function(boolSelector, value)
@@ -589,7 +618,7 @@ function CharacterSelect:createRankedSelection(player, width)
   player:connectSignal("wantsRankedChanged", rankedSelector, rankedSelector.setValue)
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
@@ -603,6 +632,9 @@ function CharacterSelect:createRankedSelection(player, width)
   return rankedSelector
 end
 
+---@param player Player
+---@param width number
+---@return BoolSelector styleSelector
 function CharacterSelect:createStyleSelection(player, width)
   local styleSelector = ui.BoolSelector({
     startValue = (player.settings.style == GameModes.Styles.MODERN),
@@ -627,7 +659,7 @@ function CharacterSelect:createStyleSelection(player, width)
   )
 
   -- player number icon
-  local playerIndex = tableUtils.indexOf(GAME.battleRoom.players, player)
+  local playerIndex = tableUtils.indexOf(self.players, player)
   local playerNumberIcon = ui.ImageContainer({
     image = themes[config.theme].images.IMG_players[playerIndex],
     hAlign = "left",
@@ -794,6 +826,10 @@ function CharacterSelect:createRankedStatusPanel()
   return rankedStatus
 end
 
+---@param player Player
+---@param height number
+---@param min integer
+---@return UiElement speedSliderContainer
 function CharacterSelect:createSpeedSlider(player, height, min)
   local speedSlider = ui.Slider({
     min = min or 1,

--- a/client/src/scenes/CharacterSelect2p.lua
+++ b/client/src/scenes/CharacterSelect2p.lua
@@ -2,6 +2,7 @@ local CharacterSelect = require("client.src.scenes.CharacterSelect")
 local class = require("common.lib.class")
 local ui = require("client.src.ui")
 
+---@class CharacterSelect2p : CharacterSelect
 local CharacterSelect2p = class(
   function (self, sceneParams)
   end,
@@ -69,9 +70,8 @@ function CharacterSelect2p:loadUserInterface()
   self.ui.grid:createElementAt(9, 6, 1, 1, "leaveButton", self.ui.leaveButton)
 
   self.ui.characterIcons = {}
-  for i = 1, #GAME.battleRoom.players do
-    local player = GAME.battleRoom.players[i]
 
+  for i, player in ipairs(self.players) do
     local panelCarousel = self:createPanelCarousel(player, panelHeight)
     self.ui.panelSelection:addElement(panelCarousel, player)
 

--- a/client/src/scenes/Scene.lua
+++ b/client/src/scenes/Scene.lua
@@ -5,10 +5,19 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 local tableUtils = require("common.lib.tableUtils")
 local SoundController = require("client.src.music.SoundController")
 
+---@alias sceneMusic ("none" | "main" | "title_screen" | "select_screen")
+
 -- Base class for a container representing a single screen of PanelAttack.
 -- Each scene should have a field called <Scene>.name = <Scene> (for identification in errors and debugging)
 -- Each scene must add its UiElements as children to its uiRoot property
+---@class Scene
+---@field uiRoot UiElement
+---@field music sceneMusic
+---@field fallbackMusic sceneMusic
+---@field keepMusic boolean
+---@overload fun(sceneParams: table): Scene
 local Scene = class(
+---@param self Scene
   function (self, sceneParams)
     self.uiRoot = ui.UiElement({x = 0, y = 0, width = consts.CANVAS_WIDTH, height = consts.CANVAS_HEIGHT})
     -- scenes may specify theme music to use that is played once they are switched to

--- a/client/src/ui/BoolSelector.lua
+++ b/client/src/ui/BoolSelector.lua
@@ -4,13 +4,20 @@ local UiElement = require(PATH .. ".UIElement")
 local class = require("common.lib.class")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 
+---@class BoolSelectorOptions : UiElementOptions
+---@field startValue boolean?
+
 --- A BoolSelector is a UIElement that shows if a setting is on or off and lets you toggle it.
+---@class BoolSelector : UiElement
+---@field value boolean
+---@field vertical boolean
 local BoolSelector = class(function(boolSelector, options)
   boolSelector.value = options.startValue or false
-  boolSelector.TYPE = "BoolSelector"
   boolSelector.vertical = false
 end,
 UiElement)
+
+BoolSelector.TYPE = "BoolSelector"
 
 function BoolSelector:onTouch(x, y)
 end

--- a/client/src/ui/Button.lua
+++ b/client/src/ui/Button.lua
@@ -4,6 +4,15 @@ local class = require("common.lib.class")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 local input = require("client.src.inputManager")
 
+---@class ButtonOptions : UiElementOptions
+---@field backgroundColor number[]?
+---@field outlineColor number[]?
+---@field onClick fun(button: Button?, input: table?, timeHeld: number?)?
+
+---@class Button : UiElement
+---@field backgroundColor number[]
+---@field outlineColor number []
+---@field onClick fun(button: Button?, input: table?, timeHeld: number?)
 local Button = class(
   function(self, options)
     self.backgroundColor = options.backgroundColor or {.3, .3, .3, .7}
@@ -13,11 +22,11 @@ local Button = class(
     self.onClick = options.onClick or function()
       GAME.theme:playValidationSfx()
     end
-
-    self.TYPE = "Button"
   end,
   UIElement
 )
+
+Button.TYPE = "Button"
 
 function Button:onTouch(x, y)
   self.backgroundColor[4] = 1

--- a/client/src/ui/LevelSlider.lua
+++ b/client/src/ui/LevelSlider.lua
@@ -4,6 +4,7 @@ local class = require("common.lib.class")
 local util = require("common.lib.util")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 
+---@class LevelSlider : Slider
 local LevelSlider = class(
   function(self, options)
     self.min = 1

--- a/client/src/ui/PixelFontLabel.lua
+++ b/client/src/ui/PixelFontLabel.lua
@@ -3,7 +3,25 @@ local UiElement = require(PATH .. ".UIElement")
 local class = require("common.lib.class")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 
-local PixelFontLabel = class(function(self, options)
+---@class PixelFontLabelOptions : UiElementOptions
+---@field text string?
+---@field charSpacing integer?
+---@field xScale number?
+---@field yScale number?
+---@field fontMap PixelFontMap?
+
+---@class PixelFontLabel : UiElement
+---@field text string
+---@field charSpacing integer
+---@field xScale number
+---@field yScale number
+---@field fontMap PixelFontMap
+---@field charDistanceScaled number
+---@overload fun(options: PixelFontLabelOptions): PixelFontLabel
+local PixelFontLabel = class(
+---@param self PixelFontLabel
+---@param options PixelFontLabelOptions
+function(self, options)
   if options.text then
     self.text = tostring(options.text):upper()
   else
@@ -42,7 +60,7 @@ function PixelFontLabel:drawSelf()
       local characterX = self.x + ((i - 1) * self.charDistanceScaled)
 
       -- Render it at the proper digit location
-      GraphicsUtil.drawQuad(self.fontMap.atlas, self.fontMap[char], characterX, self.y, 0, self.xScale, self.yScale)
+      GraphicsUtil.drawQuad(self.fontMap.atlas, self.fontMap.charToQuad[char], characterX, self.y, 0, self.xScale, self.yScale)
     end
   end
 end

--- a/client/src/ui/ScrollContainer.lua
+++ b/client/src/ui/ScrollContainer.lua
@@ -3,6 +3,9 @@ local UiElement = require(PATH .. ".UIElement")
 local class = require("common.lib.class")
 local util = require("common.lib.util")
 
+---@class ScrollContainerOptions : UiElementOptions
+---@field scrollOrientation ("vertical" | "horizontal" | nil)
+
 ---@class ScrollContainer : UiElement
 ---@field scrollOrientation string "vertical" or "horizontal"
 ---@field scrollOffset number by how many pixels the children are translated in the orientation
@@ -16,9 +19,9 @@ function(self, options)
   self.scrollOrientation = "vertical" or options.scrollOrientation
   self.scrollOffset = 0
   self.maxScrollOffset = 0
-  self.TYPE = "ScrollContainer"
 end,
 UiElement)
+ScrollContainer.TYPE = "ScrollContainer"
 
 -- bounds the scrollOffset of the container to the desired value between 0 and -maxScrollOffset
 ---@param value number desired scrollOffset value

--- a/client/src/ui/Slider.lua
+++ b/client/src/ui/Slider.lua
@@ -109,13 +109,13 @@ function Slider:getCurrentXForValue()
 end
 
 ---@param x number
----@param committed boolean if the callback should get executed
+---@param committed boolean? if the callback should get executed
 function Slider:setValueFromPos(x, committed)
   self:setValue(self:getValueForPos(x), committed)
 end
 
 ---@param newValue number
----@param committed boolean if the callback should get executed
+---@param committed boolean? if the callback should get executed
 function Slider:setValue(newValue, committed)
   self.value = util.bound(self.min, newValue, self.max)
   self.valueText:set(tostring(self.value))

--- a/client/src/ui/TextButton.lua
+++ b/client/src/ui/TextButton.lua
@@ -5,8 +5,13 @@ local class = require("common.lib.class")
 local TEXT_WIDTH_PADDING = 6
 local TEXT_HEIGHT_PADDING = 6
 
+---@class TextButtonOptions : ButtonOptions
+---@field label Label
+
 -- A TextButton is a button that sets itself apart from Button by automatically scaling its own size to fit the text inside
 -- This is different from the regular button that scales its content to fit inside itself
+---@class TextButton : Button
+---@field label Label
 local TextButton = class(function(self, options)
   self.label = options.label
   self.label.hAlign = "center"
@@ -18,7 +23,7 @@ local TextButton = class(function(self, options)
   self.width = math.max(width + TEXT_WIDTH_PADDING, self.width)
   self.height = math.max(height + TEXT_HEIGHT_PADDING, self.height)
 
-  self.TYPE = "Button"
 end, Button)
+TextButton.TYPE = "TextButton"
 
 return TextButton

--- a/client/src/ui/UIElement.lua
+++ b/client/src/ui/UIElement.lua
@@ -19,6 +19,7 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 ---@field onDrag function? touch callback for when the mouse touching the element is dragged across the screen
 ---@field onRelease function? touch callback for when the mouse touching the element is released
 ---@field onHold function? touch callback for when a touch is held on the element for a longer duration
+---@field [any] any
 
 ---@class UiElementOptions
 ---@field x number? relative x offset to the parent element (canvas if no parent)

--- a/client/src/ui/init.lua
+++ b/client/src/ui/init.lua
@@ -1,8 +1,11 @@
 local PATH = (...):gsub('%.init$', '')
 
 local ui = {
-
+  ---@type fun(options: BoolSelectorOptions): BoolSelector
+  ---@see BoolSelector
   BoolSelector = require(PATH .. ".BoolSelector"),
+  ---@type fun(options: ButtonOptions): Button
+  ---@see Button
   Button = require(PATH .. ".Button"),
   ButtonGroup = require(PATH .. ".ButtonGroup"),
   Carousel = require(PATH .. ".Carousel"),
@@ -16,19 +19,29 @@ local ui = {
   ---@see Label
   Label = require(PATH .. ".Label"),
   Leaderboard = require(PATH .. ".Leaderboard"),
+  ---@type fun(options: SliderOptions): LevelSlider
+  ---@see LevelSlider
   LevelSlider = require(PATH .. ".LevelSlider"),
   Menu = require(PATH .. ".Menu"),
   MenuItem = require(PATH .. ".MenuItem"),
   MultiPlayerSelectionWrapper = require(PATH .. ".MultiPlayerSelectionWrapper"),
   PagedUniGrid = require(PATH .. ".PagedUniGrid"),
   PanelCarousel = require(PATH .. ".PanelCarousel"),
+  ---@type fun(options: PixelFontLabelOptions): PixelFontLabel
+  ---@see PixelFontLabel
   PixelFontLabel = require(PATH .. ".PixelFontLabel"),
+  ---@type fun(options: ScrollContainerOptions): ScrollContainer
+  ---@see ScrollContainer
   ScrollContainer = require(PATH .. ".ScrollContainer"),
   ScrollText = require(PATH .. ".ScrollText"),
+  ---@type fun(options: SliderOptions): Slider
+  ---@see Slider
   Slider = require(PATH .. ".Slider"),
   StackPanel = require(PATH .. ".StackPanel"),
   StageCarousel = require(PATH .. ".StageCarousel"),
   Stepper = require(PATH .. ".Stepper"),
+  ---@type fun(options: TextButtonOptions): TextButton
+  ---@see TextButton
   TextButton = require(PATH .. ".TextButton"),
   ---@type fun(options:UiElementOptions): UiElement
   ---@see UiElement


### PR DESCRIPTION
Made as PR so I can self review better given how big this somehow turned out.

Fixes the bug where game data was written to the wrong ReplayPlayer by *not* performing any sorting on players in the BattleRoom/ClientMatch/Replay to assure that order and data is consistent so that the client-independent functions in `common` can keep the assumption that indices will always match.

Implemented this for select screen by moving side / cursor assignment in select screen to the scene itself, having it operate on a reordered shallow copy of battleRoom.players. Simple enough

Implemented this for ingame by encapsulating Theme asset access within a variety of getters and have ClientMatch assign an asset pack to each ClientStack on game start which is then directly accessed rather than directly accessing the internals of Theme.

Bunch of annotations added while I was in some of the related scenes.