### PR TITLE
Deny swaps that would kill you + some refactoring

### DIFF
--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -45,6 +45,7 @@ function(self, args)
   self.engine:connectSignal("matched", self, self.onEngineMatched)
   self.engine:connectSignal("cursorMoved", self, self.onCursorMoved)
   self.engine:connectSignal("panelsSwapped", self, self.onPanelsSwapped)
+  self.engine:connectSignal("swapDenied", self, self.onSwapDenied)
   self.engine:connectSignal("gameOver", self, self.onGameOver)
   self.engine:connectSignal("newRow", self, self.onNewRow)
   self.engine:connectSignal("finishedRun", self, self.onRun)
@@ -226,6 +227,10 @@ function PlayerStack:onPanelsSwapped()
     self.sfxSwap = true
   end
   self.analytic:register_swap()
+end
+
+function PlayerStack:onSwapDenied()
+  -- play an SFX
 end
 
 function PlayerStack:onGarbageMatched(garbagePanelCount)

--- a/common/engine/GarbageQueue.lua
+++ b/common/engine/GarbageQueue.lua
@@ -267,6 +267,7 @@ function GarbageQueue:pushTable(garbageArray)
   end
 end
 
+---@return {width: integer, height: integer, isMetal: boolean, isChain: boolean, frameEarned: integer, finalized: boolean?}?
 function GarbageQueue:peek()
   return self.stagedGarbage[#self.stagedGarbage]
 end

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -128,8 +128,7 @@ local DIRECTION_ROW = {up = 1, down = -1, left = 0, right = 0}
 --- conversely if the rise_lock happened from the start and the manual_raise never achieved a single tick of displacement of raise, this being false leads to manual_raise being set to false again, effectively cancelling the raise
 ---@field prevent_manual_raise boolean if set to true it prevents raises initiating another raise; mostly to prevent manual_raise_yet from being overwritten so it can do its cryptic work \n
 --- this set of fields can really do with a rework
----@field swap_1 boolean if there was an attempt to initiate a swap via swap1 on this frame
----@field swap_2 boolean if there was an attempt to initiate a swap via swap2 on this frame
+---@field swapThisFrame boolean if there was an attempt to initiate a swap on this frame
 ---@field cur_wait_time integer DAS delay: number of ticks a movement key has to be held before the cursor begins to move at 1 movement per frame
 ---@field cur_timer integer number of ticks the current movement key has been held
 ---@field cursorDirection CursorDirection? direction of the current movement key
@@ -248,8 +247,7 @@ local Stack = class(
     s.manual_raise = false
     s.manual_raise_yet = false
     s.prevent_manual_raise = false
-    s.swap_1 = false -- attempt to initiate a swap on this frame
-    s.swap_2 = false
+    s.swapThisFrame = false -- attempt to initiate a swap on this frame
 
     -- number of ticks a movement key has to be held before the cursor begins to move at 1 movement per frame
     s.cur_wait_time = consts.DEFAULT_INPUT_REPEAT_DELAY
@@ -844,8 +842,7 @@ function Stack.controls(self)
     local swap, up, down, left, right
     raise, swap, up, down, left, right = unpack(base64decode[sdata])
 
-    self.swap_1 = swap
-    self.swap_2 = swap
+    self.swapThisFrame = swap
 
     if up then
       new_dir = "up"
@@ -1101,15 +1098,14 @@ function Stack:simulate()
   -- Queue Swapping
   -- Note: Swapping is queued in Stack.controls for touch mode
   if self.inputMethod == "controller" then
-    if (self.swap_1 or self.swap_2) and not swapped_this_frame then
+    if self.swapThisFrame and not swapped_this_frame then
       local leftPanel = self.panels[self.cur_row][self.cur_col]
       local rightPanel = self.panels[self.cur_row][self.cur_col + 1]
       local canSwap = self:canSwap(leftPanel, rightPanel)
       if canSwap then
         self:setQueuedSwapPosition(self.cur_col, self.cur_row)
       end
-      self.swap_1 = false
-      self.swap_2 = false
+      self.swapThisFrame = false
     end
   end
   --prof.pop("new swap")

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -1123,7 +1123,7 @@ function Stack.simulate(self)
   -- Phase 3. /////////////////////////////////////////////////////////////
   -- Actions performed according to player input
 
-  self:moveCursor(self.cursorDirection)
+  self:applyCursorDirection(self.cursorDirection)
 
   --prof.push("new swap")
   -- Queue Swapping
@@ -1251,7 +1251,7 @@ function Stack.simulate(self)
 end
 
 ---@param direction CursorDirection?
-function Stack:moveCursor(direction)
+function Stack:applyCursorDirection(direction)
   --prof.push("cursor movement")
   if self.inputMethod == "touch" then
     --with touch, cursor movement happen at stack:control time
@@ -1259,8 +1259,7 @@ function Stack:moveCursor(direction)
     if direction and (self.cur_timer == 0 or self.cur_timer == self.cur_wait_time) and self.cursorLock == nil then
       local previousRow = self.cur_row
       local previousCol = self.cur_col
-      self.cur_row = util.bound(1, self.cur_row + DIRECTION_ROW[direction], self.top_cur_row)
-      self.cur_col = util.bound(1, self.cur_col + DIRECTION_COLUMN[direction], self.width - 1)
+      self:moveCursorInDirection(direction)
       self:emitSignal("cursorMoved", previousRow, previousCol)
     else
       self.cur_row = util.bound(1, self.cur_row, self.top_cur_row)
@@ -1271,6 +1270,12 @@ function Stack:moveCursor(direction)
     self.cur_timer = self.cur_timer + 1
   end
   --prof.pop("cursor movement")
+end
+
+---@param direction CursorDirection
+function Stack:moveCursorInDirection(direction)
+  self.cur_row = util.bound(1, self.cur_row + DIRECTION_ROW[direction], self.top_cur_row)
+  self.cur_col = util.bound(1, self.cur_col + DIRECTION_COLUMN[direction], self.width - 1)
 end
 
 function Stack:runCountDownIfNeeded()
@@ -1806,7 +1811,7 @@ function Stack:getActivePanelCount()
   return count, swappingCount
 end
 
-function Stack.updateRiseLock(self)
+function Stack:updateRiseLock()
   local previousRiseLock = self.rise_lock
   if self.do_countdown then
     self.rise_lock = true

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -974,6 +974,7 @@ function Stack.updatePanels(self)
     return
   end
 
+  prof.push("Stack:updatePanels")
   self.shake_time_on_frame = 0
   for row = 1, #self.panels do
     for col = 1, self.width do
@@ -981,38 +982,43 @@ function Stack.updatePanels(self)
       panel:update(self.panels)
     end
   end
+  prof.pop("Stack:updatePanels")
 end
 
-function Stack.shouldDropGarbage(self)
+function Stack:shouldDropGarbage()
   -- this is legit ugly, these should rather be returned in a parameter table
   -- or even better in a dedicated garbage class table
   local garbage = self.incomingGarbage:peek()
 
-  -- new garbage can't drop if the stack is full
-  -- new garbage always drops one by one
-  if not self.panels_in_top_row and not self:has_falling_garbage() then
-    if not self:hasActivePanels() then
-      return true
-    elseif garbage.isChain then
-      -- drop chain garbage higher than 1 row immediately
-      return garbage.height > 1
-    else
-      -- attackengine garbage higher than 1 (aka chain garbage) is treated as combo garbage
-      -- that is to circumvent the garbage queue not allowing to send multiple chains simultaneously
-      -- and because of that hack, we need to do another hack here and allow n-height combo garbage
-      -- technically garbage should get fixed garbageQueue side though so we should not reach here
-      if garbage.height > 1 then
-        logger.debug("Reached the cursed path")
+  if not garbage then
+    return false
+  else
+    -- new garbage can't drop if the stack is full
+    -- new garbage always drops one by one
+    if not self.panels_in_top_row and not self:has_falling_garbage() then
+      if not self:hasActivePanels() then
         return true
+      elseif garbage.isChain then
+        -- drop chain garbage higher than 1 row immediately
+        return garbage.height > 1
       else
-        return false
+        -- attackengine garbage higher than 1 (aka chain garbage) is treated as combo garbage
+        -- that is to circumvent the garbage queue not allowing to send multiple chains simultaneously
+        -- and because of that hack, we need to do another hack here and allow n-height combo garbage
+        -- technically garbage should get fixed garbageQueue side though so we should not reach here
+        if garbage.height > 1 then
+          logger.debug("Reached the cursed path")
+          return true
+        else
+          return false
+        end
       end
     end
   end
 end
 
 -- One run of the engine routine.
-function Stack.simulate(self)
+function Stack:simulate()
   --prof.push("simulate 1")
   -- self:prep_first_row()
   local panels = self.panels
@@ -1040,48 +1046,18 @@ function Stack.simulate(self)
   self:updateRiseLock()
   --prof.pop("new row stuff")
 
-  --prof.push("speed increase")
-  -- Increase the speed if applicable
-  if self.levelData.speedIncreaseMode == 1 then
-    -- increase per interval
-    if self.clock == self.nextSpeedIncreaseClock then
-      self.speed = min(self.speed + 1, 99)
-      self.nextSpeedIncreaseClock = self.nextSpeedIncreaseClock + DT_SPEED_INCREASE
-    end
-  elseif self.panels_to_speedup <= 0 then
-    -- mode 2: increase speed based on cleared panels
-    self.speed = min(self.speed + 1, 99)
-    self.panels_to_speedup = self.panels_to_speedup + PANELS_TO_NEXT_SPEED[self.speed]
-  end
-  --prof.pop("speed increase")
-
+  self:updateSpeed()
 
   --prof.push("passive raise")
   -- Phase 0 //////////////////////////////////////////////////////////////
   -- Stack automatic rising
   if self.behaviours.passiveRaise then
-    if not self.manual_raise and self.stop_time == 0 and not self.rise_lock then
-      if self.panels_in_top_row then
-        self.health = self.health - 1
-      else
-        self.rise_timer = self.rise_timer - 1
-        if self.rise_timer <= 0 then -- try to rise
-          self.displacement = self.displacement - 1
-          if self.displacement == 0 then
-            self.prevent_manual_raise = false
-            self.top_cur_row = self.height
-            self:new_row()
-          end
-          self.rise_timer = self.rise_timer + consts.SPEED_TO_RISE_TIME[self.speed]
-        end
-      end
-    end
+    self:advancePassiveRaise()
 
     if self:checkGameOver() then
       self:setGameOver()
     end
   end
-
   --prof.pop("passive raise")
 
   --prof.push("reset stuff")
@@ -1104,12 +1080,8 @@ function Stack.simulate(self)
   end
   --prof.pop("old swap")
 
-  prof.push("Stack:checkMatches")
   self:checkMatches()
-  prof.pop("Stack:checkMatches")
-  prof.push("Stack:updatePanels")
   self:updatePanels()
-  prof.pop("Stack:updatePanels")
 
   --prof.push("shake time updates")
   self.prev_shake_time = self.shake_time
@@ -1219,6 +1191,7 @@ function Stack.simulate(self)
   for col_idx = 1, self.width do
     if panels[self.height][col_idx]:dangerous() then
       self.panels_in_top_row = true
+      break
     end
   end
   --prof.pop("double-check panels_in_top_row")
@@ -1229,17 +1202,15 @@ function Stack.simulate(self)
     for col_idx = 1, self.width do
       if panels[row_idx][col_idx].color ~= 0 then
         self.panels_in_top_row = true
+        break
       end
     end
   end
   --prof.pop("doublecheck panels above top row")
 
-
   prof.push("pop from incoming garbage q")
-  if self.incomingGarbage:len() > 0 then
-    if self:shouldDropGarbage() then
-      self:tryDropGarbage()
-    end
+  if self:shouldDropGarbage() then
+    self:tryDropGarbage()
   end
   prof.pop("pop from incoming garbage q")
 
@@ -1276,6 +1247,42 @@ end
 function Stack:moveCursorInDirection(direction)
   self.cur_row = util.bound(1, self.cur_row + DIRECTION_ROW[direction], self.top_cur_row)
   self.cur_col = util.bound(1, self.cur_col + DIRECTION_COLUMN[direction], self.width - 1)
+end
+
+function Stack:updateSpeed()
+  --prof.push("speed increase")
+  -- Increase the speed if applicable
+  if self.levelData.speedIncreaseMode == 1 then
+    -- increase per interval
+    if self.clock == self.nextSpeedIncreaseClock then
+      self.speed = min(self.speed + 1, 99)
+      self.nextSpeedIncreaseClock = self.nextSpeedIncreaseClock + DT_SPEED_INCREASE
+    end
+  elseif self.panels_to_speedup <= 0 then
+    -- mode 2: increase speed based on cleared panels
+    self.speed = min(self.speed + 1, 99)
+    self.panels_to_speedup = self.panels_to_speedup + PANELS_TO_NEXT_SPEED[self.speed]
+  end
+  --prof.pop("speed increase")
+end
+
+function Stack:advancePassiveRaise()
+  if not self.manual_raise and self.stop_time == 0 and not self.rise_lock then
+    if self.panels_in_top_row then
+      self.health = self.health - 1
+    else
+      self.rise_timer = self.rise_timer - 1
+      if self.rise_timer <= 0 then -- try to rise
+        self.displacement = self.displacement - 1
+        if self.displacement == 0 then
+          self.prevent_manual_raise = false
+          self.top_cur_row = self.height
+          self:new_row()
+        end
+        self.rise_timer = self.rise_timer + consts.SPEED_TO_RISE_TIME[self.speed]
+      end
+    end
+  end
 end
 
 function Stack:runCountDownIfNeeded()

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -15,6 +15,7 @@ local LevelData = require("common.data.LevelData")
 table.clear = require("table.clear")
 local ReplayPlayer = require("common.data.ReplayPlayer")
 local RollbackBuffer = require("common.engine.RollbackBuffer")
+local WigglePay = require("common.engine.WigglePay")
 
 local rollbackPanelBuffer = {}
 -- this is a bit of an opportunistic thing:
@@ -769,15 +770,7 @@ function Stack.has_falling_garbage(self)
 end
 
 function Stack:swapQueued()
-  if self.queuedSwapColumn ~= 0 and self.queuedSwapRow ~= 0 then
-    return true
-  end
-  return false
-end
-
-function Stack:setQueuedSwapPosition(column, row)
-  self.queuedSwapColumn = column
-  self.queuedSwapRow = row
+  return self.queuedSwapColumn ~= 0 and self.queuedSwapRow ~= 0
 end
 
 -- Setup the stack at a new starting state
@@ -824,10 +817,7 @@ function Stack.controls(self)
         if self.cur_col ~= 0 and self.cur_row ~= 0 and cursorColumn ~= self.cur_col and cursorRow ~= 0 then
           local panel1 = self.panels[cursorRow][cursorColumn]
           local panel2 = self.panels[self.cur_row][self.cur_col]
-          if self:canSwap(panel1, panel2) then
-            local swapColumn = math.min(self.cur_col, cursorColumn)
-            self:setQueuedSwapPosition(swapColumn, cursorRow)
-          end
+          self:tryQueueSwap(panel1, panel2)
         end
         self.cur_col = cursorColumn
         self.cur_row = cursorRow
@@ -1073,7 +1063,8 @@ function Stack:simulate()
   if self:swapQueued() then
     self:swap(self.queuedSwapRow, self.queuedSwapColumn)
     swapped_this_frame = true
-    self:setQueuedSwapPosition(0, 0)
+    self.queuedSwapColumn = 0
+    self.queuedSwapRow = 0
   end
   --prof.pop("old swap")
 
@@ -1101,11 +1092,7 @@ function Stack:simulate()
     if self.swapThisFrame and not swapped_this_frame then
       local leftPanel = self.panels[self.cur_row][self.cur_col]
       local rightPanel = self.panels[self.cur_row][self.cur_col + 1]
-      local canSwap = self:canSwap(leftPanel, rightPanel)
-      if canSwap then
-        self:setQueuedSwapPosition(self.cur_col, self.cur_row)
-      end
-      self.swapThisFrame = false
+      self:tryQueueSwap(leftPanel, rightPanel)
     end
   end
   --prof.pop("new swap")
@@ -1215,6 +1202,45 @@ function Stack:simulate()
   if self.game_stopwatch_running then
     self.game_stopwatch = (self.game_stopwatch or -1) + 1
   end
+end
+
+---@param leftPanel Panel
+---@param rightPanel Panel
+---@return boolean # if the swap cost could be afforded
+function Stack:paySwapCost(leftPanel, rightPanel)
+  if self.behaviours.swapStallingMode == 1 then
+    local row = self.cur_row
+    local col = self.cur_col
+    if self.panels_in_top_row and self.pre_stop_time == 0 and self.stop_time == 0 and self.shake_time == 0 and (self.n_active_panels - self.swappingPanelCount) == 0 then
+      local newRecord = { leftId = leftPanel.id, rightId = rightPanel.id, row = row, col = col }
+      local punish = false
+      for _, oldRecord in ipairs(self.swapStallingBackLog) do
+        if deep_content_equal(newRecord, oldRecord) then
+          punish = true
+          break
+        end
+      end
+
+      if punish then
+        if self.health > self.behaviours.swapStallingPunish then
+          self.health = self.health - self.behaviours.swapStallingPunish
+          return true
+        else
+          -- there is no longer enough health, deny the swap
+          return false
+        end
+      else
+        -- mark the reverse swap of the swap initiated just now
+        self.swapStallingBackLog[#self.swapStallingBackLog+1] = { leftId = newRecord.rightId, rightId = newRecord.leftId, row = row, col = col }
+        -- and the swap itself so it's already marked in case the reverse swap happens and logic stays simple for when data is added
+        self.swapStallingBackLog[#self.swapStallingBackLog+1] = newRecord
+      end
+    elseif #self.swapStallingBackLog > 0 then
+      self.swapStallingBackLog = {}
+    end
+  end
+
+  return true
 end
 
 ---@param direction CursorDirection?
@@ -1359,6 +1385,27 @@ function Stack.setGameOver(self)
   self:emitSignal("gameOver", self)
 end
 
+---@param panel1 Panel
+---@param panel2 Panel
+---@return boolean # if the swap was queued successfully
+function Stack:tryQueueSwap(panel1, panel2)
+  local canSwap, healthCost = self:canSwap(panel1, panel2)
+  if canSwap then
+    WigglePay.registerSwap(self, panel1, panel2, healthCost or 0)
+
+    -- by convention, swap column is the left panel
+    self.queuedSwapColumn = math.min(panel1.column, panel2.column)
+    self.queuedSwapRow = panel1.row
+    return true
+  end
+
+  return false
+end
+
+---@param panel1 Panel
+---@param panel2 Panel
+---@return boolean canSwap
+---@return integer? healthCost
 function Stack:canSwap(panel1, panel2)
   if math.abs(panel1.column - panel2.column) ~= 1 or panel1.row ~= panel2.row then
     -- panels are not horizontally adjacent, can't swap
@@ -1413,7 +1460,11 @@ function Stack:canSwap(panel1, panel2)
     end
   end
 
-  return true
+  if self.behaviours.swapStallingMode == 1 then
+    return WigglePay.canSwap(self, panel1, panel2)
+  else
+    return true
+  end
 end
 
 -- Swaps panels at the current cursor location
@@ -1421,33 +1472,6 @@ function Stack:swap(row, col)
   local panels = self.panels
   local leftPanel = panels[row][col]
   local rightPanel = panels[row][col + 1]
-  if self.behaviours.swapStallingMode == 1 then
-    if self.panels_in_top_row and self.pre_stop_time == 0 and self.stop_time == 0 and self.shake_time == 0 and (self.n_active_panels - self.swappingPanelCount) == 0 then
-      local newRecord = { leftId = leftPanel.id, rightId = rightPanel.id, row = row, col = col }
-      local punish = false
-      for _, oldRecord in ipairs(self.swapStallingBackLog) do
-        if deep_content_equal(newRecord, oldRecord) then
-          punish = true
-          break
-        end
-      end
-
-      if punish then
-        self.health = self.health - self.behaviours.swapStallingPunish
-        if self:checkGameOver() then
-          self:setGameOver()
-          return
-        end
-      else
-        -- mark the reverse swap of the swap initiated just now
-        self.swapStallingBackLog[#self.swapStallingBackLog+1] = { leftId = newRecord.rightId, rightId = newRecord.leftId, row = row, col = col }
-        -- and the swap itself so it's already marked in case the reverse swap happens and logic stays simple for when data is added
-        self.swapStallingBackLog[#self.swapStallingBackLog+1] = newRecord
-      end
-    elseif #self.swapStallingBackLog > 0 then
-      self.swapStallingBackLog = {}
-    end
-  end
   self:processPuzzleSwap()
   leftPanel:startSwap(true)
   rightPanel:startSwap(false)

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -1206,45 +1206,6 @@ function Stack:simulate()
   end
 end
 
----@param leftPanel Panel
----@param rightPanel Panel
----@return boolean # if the swap cost could be afforded
-function Stack:paySwapCost(leftPanel, rightPanel)
-  if self.behaviours.swapStallingMode == 1 then
-    local row = self.cur_row
-    local col = self.cur_col
-    if self.panels_in_top_row and self.pre_stop_time == 0 and self.stop_time == 0 and self.shake_time == 0 and (self.n_active_panels - self.swappingPanelCount) == 0 then
-      local newRecord = { leftId = leftPanel.id, rightId = rightPanel.id, row = row, col = col }
-      local punish = false
-      for _, oldRecord in ipairs(self.swapStallingBackLog) do
-        if deep_content_equal(newRecord, oldRecord) then
-          punish = true
-          break
-        end
-      end
-
-      if punish then
-        if self.health > self.behaviours.swapStallingPunish then
-          self.health = self.health - self.behaviours.swapStallingPunish
-          return true
-        else
-          -- there is no longer enough health, deny the swap
-          return false
-        end
-      else
-        -- mark the reverse swap of the swap initiated just now
-        self.swapStallingBackLog[#self.swapStallingBackLog+1] = { leftId = newRecord.rightId, rightId = newRecord.leftId, row = row, col = col }
-        -- and the swap itself so it's already marked in case the reverse swap happens and logic stays simple for when data is added
-        self.swapStallingBackLog[#self.swapStallingBackLog+1] = newRecord
-      end
-    elseif #self.swapStallingBackLog > 0 then
-      self.swapStallingBackLog = {}
-    end
-  end
-
-  return true
-end
-
 ---@param direction CursorDirection?
 function Stack:applyCursorDirection(direction)
   --prof.push("cursor movement")

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -1071,6 +1071,7 @@ function Stack:simulate()
 
   self:checkMatches()
   self:updatePanels()
+  self:updateActivePanelCount()
 
   --prof.push("shake time updates")
   self.prev_shake_time = self.shake_time
@@ -1152,10 +1153,6 @@ function Stack:simulate()
     self.score = 99999
   -- lol owned
   end
-
-  --prof.push("updateActivePanels")
-  self:updateActivePanels()
-  --prof.pop("updateActivePanels")
 
   if self.puzzle and self.n_active_panels == 0 and self.n_prev_active_panels == 0 then
     if self:checkGameOver() then
@@ -1809,9 +1806,11 @@ function Stack.hasChainingPanels(self)
   return false
 end
 
-function Stack.updateActivePanels(self)
+function Stack:updateActivePanelCount()
+  --prof.push("updateActivePanelCount")
   self.n_prev_active_panels = self.n_active_panels
   self.n_active_panels, self.swappingPanelCount = self:getActivePanelCount()
+  --prof.pop("updateActivePanelCount")
 end
 
 ---@return integer activePanelCount

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -60,6 +60,13 @@ local PANELS_TO_NEXT_SPEED =
   45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
   45, 45, 45, 45, 45, 45, 45, 45, math.huge}
 
+---@alias CursorDirection ("up" | "down" | "left" | "right")
+
+---@type table<CursorDirection, integer>
+local DIRECTION_COLUMN = {up = 0, down = 0, left = -1, right = 1}
+---@type table<CursorDirection, integer>
+local DIRECTION_ROW = {up = 1, down = -1, left = 0, right = 0}
+
 ---@class Stack : BaseStack
 ---@field width integer How many columns of panels the stack has
 ---@field height integer How many rows of panels the stack has
@@ -125,7 +132,7 @@ local PANELS_TO_NEXT_SPEED =
 ---@field swap_2 boolean if there was an attempt to initiate a swap via swap2 on this frame
 ---@field cur_wait_time integer DAS delay: number of ticks a movement key has to be held before the cursor begins to move at 1 movement per frame
 ---@field cur_timer integer number of ticks the current movement key has been held
----@field cur_dir string? direction of the current movement key
+---@field cursorDirection CursorDirection? direction of the current movement key
 ---@field cur_row integer row the cursor is on
 ---@field cur_col integer column the cursor is on
 ---@field queuedSwapRow integer row in which a swap for next frame has been queued
@@ -247,7 +254,7 @@ local Stack = class(
     -- number of ticks a movement key has to be held before the cursor begins to move at 1 movement per frame
     s.cur_wait_time = consts.DEFAULT_INPUT_REPEAT_DELAY
     s.cur_timer = 0 -- number of ticks for which a new direction's been pressed
-    s.cur_dir = nil -- the direction pressed
+    s.cursorDirection = nil -- the direction pressed
     s.cur_row = 7 -- the row the cursor's on
     s.cur_col = 3 -- the column the left half of the cursor's on
     s.queuedSwapColumn = 0 -- the left column of the two columns to swap or 0 if no swap queued
@@ -398,7 +405,7 @@ function Stack:rollbackCopy()
   copy.manual_raise_yet = self.manual_raise_yet
   copy.prevent_manual_raise = self.prevent_manual_raise
   copy.cur_timer = self.cur_timer
-  copy.cur_dir = self.cur_dir
+  copy.cursorDirection = self.cursorDirection
   copy.cur_row = self.cur_row
   copy.cur_col = self.cur_col
   copy.shake_time = self.shake_time
@@ -427,6 +434,8 @@ function Stack:rollbackCopy()
   self.rollbackBuffer:saveCopy(self.clock, copy)
 end
 
+---@param stack Stack
+---@param frame integer
 local function internalRollbackToFrame(stack, frame)
   local copy = stack.rollbackBuffer:rollbackToFrame(frame)
 
@@ -455,7 +464,7 @@ local function internalRollbackToFrame(stack, frame)
   stack.manual_raise_yet = copy.manual_raise_yet
   stack.prevent_manual_raise = copy.prevent_manual_raise
   stack.cur_timer = copy.cur_timer
-  stack.cur_dir = copy.cur_dir
+  stack.cursorDirection = copy.cursorDirection
   stack.cur_row = copy.cur_row
   stack.cur_col = copy.cur_col
   stack.shake_time = copy.shake_time
@@ -848,12 +857,12 @@ function Stack.controls(self)
       new_dir = "right"
     end
 
-    if new_dir == self.cur_dir then
+    if new_dir == self.cursorDirection then
       if self.cur_timer ~= self.cur_wait_time then
         self.cur_timer = self.cur_timer + 1
       end
     else
-      self.cur_dir = new_dir
+      self.cursorDirection = new_dir
       self.cur_timer = 0
     end
   end
@@ -949,9 +958,6 @@ function Stack.receiveConfirmedInput(self, input)
   end
   --logger.debug("Player " .. self.which .. " got new input. Total length: " .. #self.confirmedInput)
 end
-
-local d_col = {up = 0, down = 0, left = -1, right = 1}
-local d_row = {up = 1, down = -1, left = 0, right = 0}
 
 function Stack.hasPanelsInTopRow(self)
   local panelRow = self.panels[self.height]
@@ -1117,25 +1123,7 @@ function Stack.simulate(self)
   -- Phase 3. /////////////////////////////////////////////////////////////
   -- Actions performed according to player input
 
-  --prof.push("cursor movement")
-  -- CURSOR MOVEMENT
-  if self.inputMethod == "touch" then
-      --with touch, cursor movement happen at stack:control time
-  else
-    if self.cur_dir and (self.cur_timer == 0 or self.cur_timer == self.cur_wait_time) and self.cursorLock == nil then
-      local previousRow = self.cur_row
-      local previousCol = self.cur_col
-      self:moveCursorInDirection(self.cur_dir)
-      self:emitSignal("cursorMoved", previousRow, previousCol)
-    else
-      self.cur_row = util.bound(1, self.cur_row, self.top_cur_row)
-    end
-  end
-
-  if self.cur_timer ~= self.cur_wait_time then
-    self.cur_timer = self.cur_timer + 1
-  end
-  --prof.pop("cursor movement")
+  self:moveCursor(self.cursorDirection)
 
   --prof.push("new swap")
   -- Queue Swapping
@@ -1262,6 +1250,29 @@ function Stack.simulate(self)
   end
 end
 
+---@param direction CursorDirection?
+function Stack:moveCursor(direction)
+  --prof.push("cursor movement")
+  if self.inputMethod == "touch" then
+    --with touch, cursor movement happen at stack:control time
+  else
+    if direction and (self.cur_timer == 0 or self.cur_timer == self.cur_wait_time) and self.cursorLock == nil then
+      local previousRow = self.cur_row
+      local previousCol = self.cur_col
+      self.cur_row = util.bound(1, self.cur_row + DIRECTION_ROW[direction], self.top_cur_row)
+      self.cur_col = util.bound(1, self.cur_col + DIRECTION_COLUMN[direction], self.width - 1)
+      self:emitSignal("cursorMoved", previousRow, previousCol)
+    else
+      self.cur_row = util.bound(1, self.cur_row, self.top_cur_row)
+    end
+  end
+
+  if self.cur_timer ~= self.cur_wait_time then
+    self.cur_timer = self.cur_timer + 1
+  end
+  --prof.pop("cursor movement")
+end
+
 function Stack:runCountDownIfNeeded()
   if self.do_countdown then
     self.game_stopwatch_running = false
@@ -1312,12 +1323,6 @@ function Stack:runCountDownIfNeeded()
       end
     end
   end
-end
-
-function Stack:moveCursorInDirection(directionString)
-  assert(directionString ~= nil and type(directionString) == "string")
-  self.cur_row = util.bound(1, self.cur_row + d_row[directionString], self.top_cur_row)
-  self.cur_col = util.bound(1, self.cur_col + d_col[directionString], self.width - 1)
 end
 
 -- Returns true if the stack is simulated past the end of the match.

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -280,6 +280,7 @@ local Stack = class(
     s:createSignal("panelLanded")
     s:createSignal("cursorMoved")
     s:createSignal("panelsSwapped")
+    s:createSignal("swapDenied")
     s:createSignal("garbageMatched")
     s:createSignal("newRow")
   end,
@@ -1089,10 +1090,14 @@ function Stack:simulate()
   -- Queue Swapping
   -- Note: Swapping is queued in Stack.controls for touch mode
   if self.inputMethod == "controller" then
-    if self.swapThisFrame and not swapped_this_frame then
-      local leftPanel = self.panels[self.cur_row][self.cur_col]
-      local rightPanel = self.panels[self.cur_row][self.cur_col + 1]
-      self:tryQueueSwap(leftPanel, rightPanel)
+    if self.swapThisFrame then
+      if swapped_this_frame then
+        self:emitSignal("swapDenied")
+      else
+        local leftPanel = self.panels[self.cur_row][self.cur_col]
+        local rightPanel = self.panels[self.cur_row][self.cur_col + 1]
+        self:tryQueueSwap(leftPanel, rightPanel)
+      end
     end
   end
   --prof.pop("new swap")
@@ -1397,9 +1402,10 @@ function Stack:tryQueueSwap(panel1, panel2)
     self.queuedSwapColumn = math.min(panel1.column, panel2.column)
     self.queuedSwapRow = panel1.row
     return true
+  else
+    self:emitSignal("swapDenied")
+    return false
   end
-
-  return false
 end
 
 ---@param panel1 Panel

--- a/common/engine/WigglePay.lua
+++ b/common/engine/WigglePay.lua
@@ -1,0 +1,69 @@
+local WigglePay = {}
+
+function WigglePay.isActive(stack)
+  if stack.behaviours.swapStallingMode == 0 then
+    return false
+  elseif stack.behaviours.swapStallingPunish == 0 then
+    return false
+  elseif not stack.panels_in_top_row then
+    return false
+  elseif stack.pre_stop_time ~= 0 then
+    return false
+  elseif stack.stop_time ~= 0 then
+    return false
+  elseif stack.shake_time ~= 0 then
+    return false
+  elseif (stack.n_active_panels - stack.swappingPanelCount) ~= 0 then
+    return false
+  end
+
+  return true
+end
+
+---@param stack Stack
+---@param panel1 Panel
+---@param panel2 Panel
+---@return boolean # if the panels can be swapped
+---@return integer healthCost
+function WigglePay.canSwap(stack, panel1, panel2)
+  if not WigglePay.isActive(stack) then
+    return true, 0
+  end
+
+  local row = stack.cur_row
+  local col = stack.cur_col
+  for _, oldRecord in ipairs(stack.swapStallingBackLog) do
+    if oldRecord.leftId == panel1.id and oldRecord.rightId == panel2.id and oldRecord.row == row and oldRecord.col == col then
+      if stack.health > stack.behaviours.swapStallingPunish then
+        return true, stack.behaviours.swapStallingPunish
+      else
+        return false, 0
+      end
+    end
+  end
+
+  return true, 0
+end
+
+---@param stack Stack
+---@param panel1 Panel
+---@param panel2 Panel
+---@param healthCost integer
+function WigglePay.registerSwap(stack, panel1, panel2, healthCost)
+  if WigglePay.isActive(stack) then
+    if healthCost == 0 then
+      local newRecord = { leftId = panel1.id, rightId = panel2.id, row = stack.cur_row, col = stack.cur_col }
+      -- mark the reverse swap of the swap initiated just now
+      stack.swapStallingBackLog[#stack.swapStallingBackLog+1] = { leftId = newRecord.rightId, rightId = newRecord.leftId, row = stack.cur_row, col = stack.cur_col }
+      -- and the swap itself so it's already marked in case the reverse swap happens and logic stays simple for when data is added
+      stack.swapStallingBackLog[#stack.swapStallingBackLog+1] = newRecord
+    else
+      stack.health = stack.health - healthCost
+    end
+  elseif #stack.swapStallingBackLog > 0 then
+    stack.swapStallingBackLog = {}
+  end
+end
+
+
+return WigglePay

--- a/common/engine/checkMatches.lua
+++ b/common/engine/checkMatches.lua
@@ -114,6 +114,7 @@ function Stack:checkMatches()
     return
   end
 
+  prof.push("Stack:checkMatches")
   --local reference = self:getMatchingPanels2()
   local matchingPanels = self:getMatchingPanels()
   local comboSize = #matchingPanels
@@ -152,6 +153,7 @@ function Stack:checkMatches()
   end
 
   self:clearChainingFlags()
+  prof.pop("Stack:checkMatches")
 end
 
 -- getMatchingPanels2 is a reference implementation

--- a/common/tests/engine/StackTests.lua
+++ b/common/tests/engine/StackTests.lua
@@ -56,8 +56,7 @@ local function basicSwapTest()
 
   local leftPanel = stack.panels[1][1]
   local rightPanel = stack.panels[1][2]
-  assert(stack:canSwap(leftPanel, rightPanel), "should be able to swap")
-  stack:setQueuedSwapPosition(1, 1)
+  assert(stack:tryQueueSwap(leftPanel, rightPanel), "should be able to swap")
   assert(stack.queuedSwapRow == 1)
   stack:new_row()
   assert(stack.queuedSwapRow == 2)
@@ -182,8 +181,9 @@ local function swapStalling1Test1()
   assert(match.clock > preWiggleInputs:len(), "expected to live before starting to wiggle")
   assert(inputs:len() > match.clock and stack.game_over_clock > 0, "expected the stack to go game over")
   -- at clock time 197 we get 59 frames of prestop which have run out at 257, followed by 6 frames of hover and 2 frames until the frames have finished landing
-  -- wiggling starts at frame 252 for 28 frames on every 3rd frame with swaps on 255, 258, 261, 264, 267, the latter 2 are after landing so the swap at 267 should kill us
-  assert(stack.game_over_clock == 267)
+  -- wiggling starts at frame 252 for 28 frames on every 3rd frame with swaps on 255, 258, 261, 264, 267, the latter 2 are after landing so the swap at 267 should get denied
+  -- following which it takes 5 more frames until passive raise kills us
+  assert(stack.game_over_clock == 272)
 end
 
 swapStalling1Test1()

--- a/common/tests/engine/StackTests.lua
+++ b/common/tests/engine/StackTests.lua
@@ -182,8 +182,8 @@ local function swapStalling1Test1()
   assert(inputs:len() > match.clock and stack.game_over_clock > 0, "expected the stack to go game over")
   -- at clock time 197 we get 59 frames of prestop which have run out at 257, followed by 6 frames of hover and 2 frames until the frames have finished landing
   -- wiggling starts at frame 252 for 28 frames on every 3rd frame with swaps on 255, 258, 261, 264, 267, the latter 2 are after landing so the swap at 267 should get denied
-  -- following which it takes 5 more frames until passive raise kills us
-  assert(stack.game_over_clock == 272)
+  -- following which it takes 2 more frames until passive raise kills us
+  assert(stack.game_over_clock == 269)
 end
 
 swapStalling1Test1()

--- a/docs/differences.txt
+++ b/docs/differences.txt
@@ -10,7 +10,7 @@ This is most noticeable if you use L or R, the stack will sort of jitter on its 
 There are no plans to implement this.
 
 In Tetris Attack, only one pair of panels can be swapping at any time, and the new swap can only be created in some frames of the old swap.
-In Panel Attack, the timing is unrestricted.
+In Panel Attack, swaps cannot occur on consecutive frames, but the timing for back-to-back swaps is less strict than the rule enforced by Tetris Attack.
 
 In Tetris Attack, chains past 13 do not generate bigger chain blocks.  
 Panel Attack's chain blocks are always (chain length - 1) high.


### PR DESCRIPTION
Some refactoring because I wanted to see if I could consolidate the queuing of the swap and the swap itself as relative to the panel updates they are after each other.
Not doable though due to #624 but I did extract some functions before running into that issue.

The queueing has been consolidated into a single function though so that there is no longer any difference between keyboard/controller for trying to queue a swap, just throw the two panels in and the rest is handled.
This was mainly done so I only need to plug the swap denial / payment into a single spot.
That logic in particular ended up in a static WigglePay table that can get extended and changed without flaunting its complexity in the Stack code, which highlights its "plugin" character.

Additionally I did the initial step for #608 by creating a Signal and emitting whenever a swap is denied on purpose.
We probably want to have some nuance specifically for touch there but that will be up to the client side code.
