### PR TITLE
Add a stop danger animation

### DIFF
--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -1591,22 +1591,30 @@ function PlayerStack:getAttackPatternData()
   return data, state
 end
 
-function PlayerStack.updateDangerBounce(self)
+-- calculate which columns should bounce
+function PlayerStack:updateDangerBounce()
   if self.engine.puzzle then
     return
   end
 
-  -- calculate which columns should bounce
+  -- reset state
   self.danger = false
-  local panelRow = self.engine.panels[self.engine.height - 1]
-  for idx = 1, self.engine.width do
-    if panelRow[idx]:dangerous() then
-      self.danger = true
-      self.danger_col[idx] = true
-    else
-      self.danger_col[idx] = false
+  for column = 1, self.engine.width do
+    self.danger_col[column] = false
+  end
+
+  for row = self.engine.height - 1, self.engine.height do
+    local panelRow = self.engine.panels[row]
+    if panelRow then
+      for idx = 1, self.engine.width do
+        if panelRow[idx]:dangerous() then
+          self.danger = true
+          self.danger_col[idx] = true
+        end
+      end
     end
   end
+
   if self.danger then
     if self.engine.panels_in_top_row and self.engine.speed ~= 0 and not self.engine.puzzle then
       -- Player has topped out, panels hold the "flattened" frame

--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -1325,7 +1325,7 @@ function PlayerStack:drawPanels(garbageImages, shockGarbageImages, shakeOffset)
                   drawGfxScaled(self, garbageImages.pop, draw_x, draw_y, 0, 16 / popped_w, 16 / popped_h)
                 end
               elseif panel.y_offset == -1 then
-                panelSet:addToDraw(panel, draw_x, draw_y, self.gfxScale)
+                panelSet:addToDraw(panel, draw_x, draw_y, self.gfxScale, self.danger_col, self.danger_timer, self.engine.stop_time)
               end
             else
               if shouldFlashForFrame(flash_time) == false then
@@ -1349,7 +1349,7 @@ function PlayerStack:drawPanels(garbageImages, shockGarbageImages, shakeOffset)
             end
           end
         else
-          panelSet:addToDraw(panel, draw_x, draw_y, self.gfxScale, self.danger_col, self.danger_timer)
+          panelSet:addToDraw(panel, draw_x, draw_y, self.gfxScale, self.danger_col, self.danger_timer, self.engine.stop_time)
         end
       end
     end

--- a/client/src/mods/Panels.lua
+++ b/client/src/mods/Panels.lua
@@ -15,6 +15,7 @@ local ANIMATION_STATES = {
 
 local OPTIONAL_ANIMATION_STATES = {
   "garbageBounce",
+  "panic",
 }
 
 local DEFAULT_PANEL_ANIM =
@@ -322,8 +323,8 @@ function Panels:load()
     self:loadSheets()
   end
 
-  if self.sheetConfig.dangerStop == nil then
-    self.sheetConfig.dangerStop = self.sheetConfig.danger
+  if self.sheetConfig.panic == nil then
+    self.sheetConfig.panic = self.sheetConfig.danger
   end
   
   self.scale = 16 / self.size
@@ -446,9 +447,11 @@ local function getGarbageBounceProps(panelSet, panel)
 end
 
 local function getDangerBounceProps(panelSet, panel, dangerTimer, stopTime)
-  local conf = panelSet.sheetConfig.danger
+  local conf
   if stopTime > 0 then
-    conf = panelSet.sheetConfig.dangerStop
+    conf = panelSet.sheetConfig.danger
+  else
+    conf = panelSet.sheetConfig.panic
   end
   -- dangerTimer counts up from 0 but top out and getting out of danger force it back to 0
   local frame = ceil(wrap(1, dangerTimer + 1 + floor((panel.column - 1) / 2), conf.durationPerFrame * conf.frames) / conf.durationPerFrame)

--- a/client/src/mods/Panels.lua
+++ b/client/src/mods/Panels.lua
@@ -322,6 +322,10 @@ function Panels:load()
     self:loadSheets()
   end
 
+  if self.sheetConfig.dangerStop == nil then
+    self.sheetConfig.dangerStop = self.sheetConfig.danger
+  end
+  
   self.scale = 16 / self.size
 
   self.quad = love.graphics.newQuad(0, 0, self.size, self.size, self.sheets[1])
@@ -441,21 +445,24 @@ local function getGarbageBounceProps(panelSet, panel)
   end
 end
 
-local function getDangerBounceProps(panelSet, panel, dangerTimer)
+local function getDangerBounceProps(panelSet, panel, dangerTimer, stopTime)
   local conf = panelSet.sheetConfig.danger
+  if stopTime > 0 then
+    conf = panelSet.sheetConfig.dangerStop
+  end
   -- dangerTimer counts up from 0 but top out and getting out of danger force it back to 0
   local frame = ceil(wrap(1, dangerTimer + 1 + floor((panel.column - 1) / 2), conf.durationPerFrame * conf.frames) / conf.durationPerFrame)
   return conf, frame
 end
 
-function Panels:getDrawProps(panel, x, y, dangerCol, dangerTimer)
+function Panels:getDrawProps(panel, x, y, dangerCol, dangerTimer, stopTime)
   local conf
   local frame
   local animationName
   if panel.state == "normal" then
     if dangerCol[panel.column] then
       animationName = "danger"
-      conf, frame = getDangerBounceProps(self, panel, dangerTimer)
+      conf, frame = getDangerBounceProps(self, panel, dangerTimer, stopTime)
     else
       animationName = "normal"
       -- normal has no timer at the moment, therefore restricted to 1 frame
@@ -515,7 +522,7 @@ function Panels:getDrawProps(panel, x, y, dangerCol, dangerTimer)
       conf, frame = getGarbageBounceProps(self, panel)
     elseif dangerCol[panel.column] and self.sheetConfig.garbageBounce then
       animationName = "danger"
-      conf, frame = getDangerBounceProps(self, panel, dangerTimer)
+      conf, frame = getDangerBounceProps(self, panel, dangerTimer, stopTime)
     else
       animationName = "hovering"
       conf = self.sheetConfig.hovering
@@ -536,7 +543,7 @@ function Panels:getDrawProps(panel, x, y, dangerCol, dangerTimer)
       conf, frame = getGarbageBounceProps(self, panel)
     elseif dangerCol[panel.column] then
       animationName = "danger"
-      conf, frame = getDangerBounceProps(self, panel, dangerTimer)
+      conf, frame = getDangerBounceProps(self, panel, dangerTimer, stopTime)
     else
       animationName = "falling"
       conf = self.sheetConfig.falling
@@ -591,13 +598,14 @@ end
 -- clock: Stack.clock to calculate animation frames
 -- danger: nil - no danger, false - regular danger, true - panic
 -- dangerTimer: remaining time for which the danger animation continues 
-function Panels:addToDraw(panel, x, y, stackScale, danger, dangerTimer)
+-- stopTime: the remaining stop time
+function Panels:addToDraw(panel, x, y, stackScale, danger, dangerTimer, stopTime)
   if panel.color == 9 then
     love.graphics.draw(self.greyPanel, x * stackScale, y * stackScale, 0, self.scale * stackScale)
   else
     local batch = self.batches[panel.color]
     local conf, frame
-    conf, frame, x, y = self:getDrawProps(panel, x, y, danger, dangerTimer)
+    conf, frame, x, y = self:getDrawProps(panel, x, y, danger, dangerTimer, stopTime)
 
     self.quad:setViewport((frame - 1) * self.size, (conf.row - 1) * self.size, self.size, self.size)
     -- scale / 3 because for the current standard size of 16

--- a/docs/panels.md
+++ b/docs/panels.md
@@ -130,12 +130,12 @@ Panels in the states "normal", "falling" and "hovering"* in a column that is clo
 This animation is staggered across columns in pairs of two, loops as long as the player is not topped out and pauses on the current frame while the player has stop time.  
 Whenever the player is topped out, the animation resets to the first frame and is held there so the first frame of this animation should NOT match the normal frame.
 
-Specifying a panic animation is OPTIONAL and the danger animation will be used for both parts.
+Specifying a panic animation is OPTIONAL and the danger animation will be used for both parts if no panic animation is supplied.
 
 Whenever the player has stop time, the danger frame will be displayed.  
 Whenever the player has no stop time, the panic frame will be displayed.  
 
-This means that if a separate panic animation is supplied, only the panic animation will visibly play and whenever stop time is gained, the animation will freeze on the corresponding danger frame. Otherwise the danger animation plays and freezes in accordance with stop time.
+This means that if a separate panic animation is supplied the danger animation will never do full animation because it will always be freezed at frame 1 or whatever frame you got stop time.
 
 As they share a timer, it is recommended to use the same length / timing for danger and panic as otherwise the transition between the two may look odd.
 

--- a/docs/panels.md
+++ b/docs/panels.md
@@ -137,13 +137,10 @@ Whenever the player has no stop time, the panic frame will be displayed.
 
 This means that if a separate panic animation is supplied, only the panic animation will visibly play and whenever stop time is gained, the animation will freeze on the corresponding danger frame. Otherwise the danger animation plays and freezes in accordance with stop time.
 
+As they share a timer, it is recommended to use the same length / timing for danger and panic as otherwise the transition between the two may look odd.
+
 *Panels in the "hovering" state only adopt the danger frames if the garbageBounce animation is used.
 
-#### panic
-
-This is an OPTIONAL animation, if not specified it will default to the danger animation.  
-Displayed under the same conditions as danger except when there is NO stop time left.
-Like with danger
 
 #### garbagePop
 

--- a/docs/panels.md
+++ b/docs/panels.md
@@ -122,12 +122,20 @@ Currently a single frame and not animatable.
 When a player loses all health and goes game over, all panels in their stack are displayed with their dead frame.  
 Currently a single frame and not animatable.
 
-#### danger
+#### danger and panic
 
-Panels in the states "normal", "falling" and "hovering"* in a column that is close to the top or even touching it, perform a danger animation.  
-This animation loops as long as the player is not topped out OR has stop time remaining while topped out.  
-If a top out occurs without stop time, the first panic frame is held instead.  
-If no panic animation is specified, the first frame of the danger animation is displayed so it should NOT match the normal frame.
+These are explained together because they share their internal animation timer.
+
+Panels in the states "normal", "falling" and "hovering"* in a column that is close to the top perform a danger or panic animation.  
+This animation is staggered across columns in pairs of two, loops as long as the player is not topped out and pauses on the current frame while the player has stop time.  
+Whenever the player is topped out, the animation resets to the first frame and is held there so the first frame of this animation should NOT match the normal frame.
+
+Specifying a panic animation is OPTIONAL and the danger animation will be used for both parts.
+
+Whenever the player has stop time, the danger frame will be displayed.  
+Whenever the player has no stop time, the panic frame will be displayed.  
+
+This means that if a separate panic animation is supplied, only the panic animation will visibly play and whenever stop time is gained, the animation will freeze on the corresponding danger frame. Otherwise the danger animation plays and freezes in accordance with stop time.
 
 *Panels in the "hovering" state only adopt the danger frames if the garbageBounce animation is used.
 

--- a/docs/panels.md
+++ b/docs/panels.md
@@ -124,9 +124,18 @@ Currently a single frame and not animatable.
 
 #### danger
 
-Panels in the states "normal", "falling" and "hovering" in a column that is close to the top or even touching it, perform a danger animation.  
-This animation loops but is held on its first frame if the player is topped out and has no stop time left.  
-To make this panic state visible, the first frame of the danger animation should NOT match the normal frame.
+Panels in the states "normal", "falling" and "hovering"* in a column that is close to the top or even touching it, perform a danger animation.  
+This animation loops as long as the player is not topped out OR has stop time remaining while topped out.  
+If a top out occurs without stop time, the first panic frame is held instead.  
+If no panic animation is specified, the first frame of the danger animation is displayed so it should NOT match the normal frame.
+
+*Panels in the "hovering" state only adopt the danger frames if the garbageBounce animation is used.
+
+#### panic
+
+This is an OPTIONAL animation, if not specified it will default to the danger animation.  
+Displayed under the same conditions as danger except when there is NO stop time left.
+Like with danger
 
 #### garbagePop
 


### PR DESCRIPTION
Adds an animation to panels for when you are in danger but have stop time.

This allows you an easier time of telling if you have stop time rather than looking at the colors on the multibar.

This feature is optional, by default the stop danger animation is the same as the normal danger animation. Any panels that have the feature can easily be disabled by changing the row in the config.

Panels provided for testing
[JamBox Crisp PA.zip](https://github.com/user-attachments/files/19155153/JamBox.Crisp.PA.zip)
