### PR TITLE
Extract match from client stack

### DIFF
--- a/client/src/ClientStack.lua
+++ b/client/src/ClientStack.lua
@@ -31,7 +31,6 @@ end
 ---@field multi_shakeQuad love.Quad
 ---@field danger_music boolean
 ---@field garbageSource ClientStack The stack the garbage assets are used from
----@field match ClientMatch
 ---@field assets IngameAssetPack
 ---@field renderIndex integer determines the position of the stack and how some elements are rendered
 ---@field player_number integer used for display ordering
@@ -45,7 +44,6 @@ function(self, args)
 
   assert(args.engine)
   assert(args.characterId)
-  assert(args.match)
 
   self.engine = args.engine
   -- player number according to the multiplayer server, for game outcome reporting 
@@ -53,7 +51,6 @@ function(self, args)
   self.is_local = args.player and args.player.isLocal or args.engine.is_local
   self.character = characters[args.characterId]
   self.theme = args.theme or themes[config.theme]
-  self.match = args.match
 
   self.panels_dir = args.panels_dir
   if not self.panels_dir or not panels[self.panels_dir] then
@@ -443,12 +440,7 @@ end
 
 ---@return boolean
 function ClientStack:game_ended()
-  if self.engine:game_ended() then
-    return true
-  else
-    -- for display we may also want to know if the match has ended
-    return self.match.engine.ended
-  end
+  return self.engine:game_ended()
 end
 
 ---@param assetPack IngameAssetPack
@@ -487,7 +479,8 @@ function ClientStack:runGameOver()
   error("did not implement runGameOver")
 end
 
-function ClientStack:render()
+---@param matchEnded boolean?
+function ClientStack:render(matchEnded)
   error("did not implement render")
 end
 

--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -26,6 +26,7 @@ require("client.src.BattleRoom")
 local prof = require("common.lib.zoneProfiler")
 local tableUtils = require("common.lib.tableUtils")
 local system = require("client.src.system")
+local ModController = require("client.src.mods.ModController")
 
 local RichPresence = require("client.lib.rich_presence.RichPresence")
 
@@ -258,6 +259,7 @@ function Game:setupRoutine()
   self:writeReleaseStreamDefinition()
 
   self:initializeLocalPlayer()
+  ModController:loadModFor(characters[GAME.localPlayer.settings.characterId], GAME.localPlayer, true)
 end
 
 -- GAME.localPlayer is the standard player for battleRooms that don't get started from replays/spectate

--- a/client/src/Player.lua
+++ b/client/src/Player.lua
@@ -99,16 +99,14 @@ function Player:reset()
 end
 
 ---@param engineStack Stack
----@param match ClientMatch
 ---@return PlayerStack
-function Player:createClientStack(engineStack, match)
+function Player:createClientStack(engineStack)
   local args = {
     engine = engineStack,
     player_number = self.playerNumber,
     panels_dir = self.settings.panelId,
     characterId = self.settings.characterId,
     player = self,
-    match = match,
   }
 
   if self.settings.style == GameModes.Styles.MODERN then

--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -938,9 +938,7 @@ function PlayerStack:render(matchEnded)
   self:drawFrame()
   self:drawWall(shakeOffset, self.engine.height)
   -- Draw the cursor
-  if self:game_ended() == false then
-    self:render_cursor(shakeOffset, matchEnded)
-  end
+  self:render_cursor(shakeOffset, matchEnded)
   self:drawCountdown()
   self:resetDrawArea()
 
@@ -992,7 +990,7 @@ function PlayerStack:render_cursor(shake, matchEnded)
   local scale_y = 24 / cursor.image:getHeight()
   local xPosition = (engine.cur_col - 1) * panelWidth
 
-  if matchEnded then
+  if self:game_ended() or matchEnded then
     GraphicsUtil.setColor(1, 1, 1, 0.3)
   end
 
@@ -1003,9 +1001,7 @@ function PlayerStack:render_cursor(shake, matchEnded)
     drawGfxScaled(self, cursor.image, xPosition, (11 - (engine.cur_row)) * panelWidth + engine.displacement - shake, 0, scale_x, scale_y)
   end
 
-  if matchEnded then
-    GraphicsUtil.setColor(1, 1, 1, 1)
-  end
+  GraphicsUtil.setColor(1, 1, 1, 1)
 end
 
 -- Draw the stop time and healthbars

--- a/client/src/PlayerStack.lua
+++ b/client/src/PlayerStack.lua
@@ -910,7 +910,8 @@ function PlayerStack:drawDebugPanels(shakeOffset)
 end
 
 -- Renders the player's stack on screen
-function PlayerStack.render(self)
+---@param matchEnded boolean?
+function PlayerStack:render(matchEnded)
   prof.push("Stack:render")
   if self.canvas == nil then
     return
@@ -938,7 +939,7 @@ function PlayerStack.render(self)
   self:drawWall(shakeOffset, self.engine.height)
   -- Draw the cursor
   if self:game_ended() == false then
-    self:render_cursor(shakeOffset)
+    self:render_cursor(shakeOffset, matchEnded)
   end
   self:drawCountdown()
   self:resetDrawArea()
@@ -966,7 +967,9 @@ function PlayerStack:drawRating()
 end
 
 -- Draw the stacks cursor
-function PlayerStack:render_cursor(shake)
+---@param shake integer
+---@param matchEnded boolean?
+function PlayerStack:render_cursor(shake, matchEnded)
   local engine = self.engine
   if engine.inputMethod == "touch" then
     if engine.cur_row == 0 and engine.cur_col == 0 then
@@ -989,11 +992,19 @@ function PlayerStack:render_cursor(shake)
   local scale_y = 24 / cursor.image:getHeight()
   local xPosition = (engine.cur_col - 1) * panelWidth
 
+  if matchEnded then
+    GraphicsUtil.setColor(1, 1, 1, 0.3)
+  end
+
   if self.inputMethod == "touch" then
     drawQuadGfxScaled(self, cursor.image, cursor.touchQuads[1], xPosition, (11 - (engine.cur_row)) * panelWidth + engine.displacement - shake, 0, scale_x, scale_y)
     drawQuadGfxScaled(self, cursor.image, cursor.touchQuads[2], xPosition + 12, (11 - (engine.cur_row)) * panelWidth + engine.displacement - shake, 0, scale_x, scale_y)
   else
     drawGfxScaled(self, cursor.image, xPosition, (11 - (engine.cur_row)) * panelWidth + engine.displacement - shake, 0, scale_x, scale_y)
+  end
+
+  if matchEnded then
+    GraphicsUtil.setColor(1, 1, 1, 1)
   end
 end
 

--- a/client/src/scenes/PuzzleMenu.lua
+++ b/client/src/scenes/PuzzleMenu.lua
@@ -4,6 +4,8 @@ local ui = require("client.src.ui")
 local class = require("common.lib.class")
 local MessageTransition = require("client.src.scenes.Transitions.MessageTransition")
 local LevelPresets      = require("common.data.LevelPresets")
+local consts = require("common.engine.consts")
+local Stack = require("common.engine.Stack")
 
 -- Scene for the puzzle selection menu
 ---@class PuzzleMenu : Scene
@@ -115,6 +117,10 @@ function PuzzleMenu:load(sceneParams)
 
   self.uiRoot:addChild(self.menu)
   self.uiRoot:addChild(self.puzzleLabel)
+
+  local name, puzzleSet = next(GAME.puzzleSets)
+  local puzzle = puzzleSet.puzzles[1]
+  self.puzzlePreviewStack = self:getDisplayStack(puzzle)
 end
 
 function PuzzleMenu:update(dt)
@@ -123,7 +129,31 @@ end
 
 function PuzzleMenu:draw()
   themes[config.theme].images.bg_main:draw()
+  self.puzzlePreviewStack:render(false)
   self.uiRoot:draw()
+end
+
+---@param puzzle Puzzle
+function PuzzleMenu:getDisplayStack(puzzle)
+  local gameMode = puzzle:toGameMode()
+  local args = {
+    which = 1,
+    levelData = LevelPresets.getModern(config.puzzle_level or 5),
+    is_local = false,
+    stackOverConditions = gameMode.matchRules.stackOverConditions,
+    stackWinConditions = gameMode.matchRules.stackWinConditions,
+    panelSource = puzzle:toPanelSource(),
+    inputMethod = "controller",
+    stackSetupModifications = gameMode.matchRules.stackSetupModifications or {},
+    engineVersion = consts.ENGINE_VERSION,
+  }
+  local engineStack = Stack(args)
+
+  local playerStack = GAME.localPlayer:createClientStack(engineStack)
+  playerStack:moveForRenderIndex(2)
+  engineStack:starting_state()
+
+  return playerStack
 end
 
 return PuzzleMenu

--- a/client/src/scenes/PuzzleMenu.lua
+++ b/client/src/scenes/PuzzleMenu.lua
@@ -117,10 +117,6 @@ function PuzzleMenu:load(sceneParams)
 
   self.uiRoot:addChild(self.menu)
   self.uiRoot:addChild(self.puzzleLabel)
-
-  local name, puzzleSet = next(GAME.puzzleSets)
-  local puzzle = puzzleSet.puzzles[1]
-  self.puzzlePreviewStack = self:getDisplayStack(puzzle)
 end
 
 function PuzzleMenu:update(dt)
@@ -129,7 +125,6 @@ end
 
 function PuzzleMenu:draw()
   themes[config.theme].images.bg_main:draw()
-  self.puzzlePreviewStack:render(false)
   self.uiRoot:draw()
 end
 

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -637,7 +637,7 @@ function Stack:swapQueued()
 end
 
 -- create the initial board
-function Stack:starting_state(n)
+function Stack:starting_state()
   local rowCount = self.panelSource:getStartingBoardHeight(self)
   -- +1 because the new row spawns in row 0 but we want the bottom row of the starting board in row 1
   for i = 1, rowCount + 1 do


### PR DESCRIPTION
- Extracts match from ClientStack and instead allow to pass the match state into its render function
- Draws stack cursors with reduced opacity when the match is over
- Provides a function in PuzzleMenu to get a standalone PlayerStack that can be rendered for puzzle previews.