### PR TITLE
Fixed issue #691 by using math.floatsEqualWithPrecision to prevent un…

### DIFF
--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -345,13 +345,15 @@ function Game:updateMouseVisibility(dt)
 end
 
 function Game:handleResize(newWidth, newHeight)
-  self:updateCanvasPositionAndScale(newWidth, newHeight)
-  if self.battleRoom and self.battleRoom.match then
-    self.needsAssetReload = true
-  else
-    self:refreshCanvasAndImagesForNewScale()
+  local positionChanged, scaleChanged = self:updateCanvasPositionAndScale(newWidth, newHeight)
+  if scaleChanged then
+    if self.battleRoom and self.battleRoom.match then
+      self.needsAssetReload = true
+    else
+      self:refreshCanvasAndImagesForNewScale()
+    end
+    self.showGameScaleUntil = self.timer + 5
   end
-  self.showGameScaleUntil = self.timer + 5
 end
 
 -- Called every few fractions of a second to update the game
@@ -543,8 +545,15 @@ function Game:toggleFullscreen()
 end
 
 -- Updates the scale and position values to use up the right size of the window based on the user's settings.
+---@return boolean positionChanged
+---@return boolean scaleChanged
 function Game:updateCanvasPositionAndScale(newWindowWidth, newWindowHeight)
   logger.debug("Updating canvas scale with args " .. newWindowWidth .. "," .. newWindowHeight)
+
+  local oldCanvasX = self.canvasX
+  local oldCanvasY = self.canvasY
+  local oldCanvasXScale = self.canvasXScale
+  local oldCanvasYScale = self.canvasYScale
 
   -- we want to draw at integer coordinates to prevent weird interpolation
   if newWindowWidth % 2 > 0 then
@@ -589,6 +598,10 @@ function Game:updateCanvasPositionAndScale(newWindowWidth, newWindowHeight)
     self.canvasXScale = newScale
     self.canvasYScale = newScale
   end
+
+  local positionChanged = oldCanvasX ~= self.canvasX or oldCanvasY ~= self.canvasY
+  local scaleChanged = not (math.floatsEqualWithPrecision(oldCanvasXScale, self.canvasXScale, 4) and math.floatsEqualWithPrecision(oldCanvasYScale, self.canvasYScale, 4))
+  return positionChanged, scaleChanged
 end
 
 -- Reloads the canvas and all images / fonts for the new game scale

--- a/client/src/config.lua
+++ b/client/src/config.lua
@@ -1,3 +1,4 @@
+local JsonSafePrecision = require("common.data.JsonSafePrecision")
 json = require("common.lib.dkjson")
 local util = require("common.lib.util")
 local fileUtils = require("client.src.FileUtils")
@@ -260,7 +261,7 @@ config = {
             configTable.popfx = read_data.popfx
           end
           if type(read_data.shakeIntensity) == "number" then
-            configTable.shakeIntensity = util.bound(0.5, read_data.shakeIntensity, 1)
+            configTable.shakeIntensity = util.bound(0.5, JsonSafePrecision.toSafePrecision(read_data.shakeIntensity), 1)
           end
           if type(read_data.cardfx_scale) == "number" then
             configTable.cardfx_scale = util.bound(1, read_data.cardfx_scale, 200)
@@ -282,7 +283,7 @@ config = {
             configTable.gameScaleType = read_data.gameScaleType
           end
           if type(read_data.gameScaleFixedValue) == "number" then
-            configTable.gameScaleFixedValue = read_data.gameScaleFixedValue
+            configTable.gameScaleFixedValue = JsonSafePrecision.toSafePrecision(read_data.gameScaleFixedValue)
           end
 
           if type(read_data.windowWidth) == "number" then

--- a/client/src/scenes/OptionsMenu.lua
+++ b/client/src/scenes/OptionsMenu.lua
@@ -13,6 +13,7 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 local util = require("common.lib.util")
 local ModManagement = require("client.src.scenes.ModManagement")
 local system = require("client.src.system")
+local JsonSafePrecision = require("common.data.JsonSafePrecision")
 local logger = require("common.lib.logger")
 local prof = require("common.lib.zoneProfiler")
 
@@ -345,13 +346,12 @@ function OptionsMenu:loadGraphicsMenu()
   })
 
   local function scaleSettingsChanged()
-    GAME.showGameScaleUntil = GAME.timer + 10
     local newPixelWidth, newPixelHeight = love.graphics.getDimensions()
-    local previousXScale = GAME.canvasXScale
     logger.debug("Updating canvas scale from options")
-    GAME:updateCanvasPositionAndScale(newPixelWidth, newPixelHeight)
-    if previousXScale ~= GAME.canvasXScale then
+    local positionChanged, scaleChanged = GAME:updateCanvasPositionAndScale(newPixelWidth, newPixelHeight)
+    if scaleChanged then
       GAME:refreshCanvasAndImagesForNewScale()
+      GAME.showGameScaleUntil = GAME.timer + 10
     end
   end
 
@@ -364,7 +364,7 @@ function OptionsMenu:loadGraphicsMenu()
       tickLength = 1,
       onlyChangeOnRelease = true, -- performance is bad so don't change till release
       onValueChange = function(slider)
-        config.gameScaleFixedValue = slider.value
+        config.gameScaleFixedValue = JsonSafePrecision.toSafePrecision(slider.value)
         scaleSettingsChanged()
       end
     })
@@ -416,7 +416,7 @@ function OptionsMenu:loadGraphicsMenu()
       tickAmount = 5,
       tickLength = 10,
       onValueChange = function(slider)
-        config.shakeIntensity = slider.value / 100
+        config.shakeIntensity = JsonSafePrecision.toSafePrecision(slider.value / 100)
       end
     })
     return slider


### PR DESCRIPTION
…necessary asset reloads when window resizes but scale doesn't actually change (common on Android).

Also fix config values saving with excessive precision by using JsonSafePrecision for
  gameScaleFixedValue and shakeIntensity