### PR TITLE
Puzzle level fixes

### DIFF
--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -30,6 +30,7 @@ local GeneratorSource = require("common.engine.GeneratorSource")
 ---@field match ClientMatch
 ---@field panelSource table?
 ---@field sceneParameters table?
+---@field preferredStageId string? if set, this stage will be used for all matches in the session
 ---@overload fun(mode: GameMode, gameScene: table?): BattleRoom
 BattleRoom = class(
 function(self, mode, gameScene)

--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -368,7 +368,13 @@ function BattleRoom:startMatch(replay)
   match:start()
   self.match = match
   self.state = BattleRoom.states.MatchInProgress
-  local transition = BlackFadeTransition(GAME.timer, 0.4, Easings.getSineIn())
+
+  -- Use instant transition if requested, otherwise fade
+  local transition = nil
+  if not (self.sceneParameters and self.sceneParameters.useInstantTransition) then
+    transition = BlackFadeTransition(GAME.timer, 0.4, Easings.getSineIn())
+  end
+
   local scene = self:createScene(match)
   scene:load()
   GAME.navigationStack:push(scene, transition)

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -695,19 +695,6 @@ function ClientMatch:getWinners()
   end
 end
 
-function ClientMatch:resetPuzzle()
-  -- basically rewinding the match but clearing all the player inputs before it can rerun, effectively resulting in a restart
-  -- frame 0 is always saved as a rollback copy even if there is otherwise no reason to save copies
-  self.engine:rewindToFrame(0)
-  local stackEngine = self.engine.stacks[1]
-  stackEngine.confirmedInput = {}
-  self.players[1]:incrementWinCount()
-  -- rollback data is discarded so we need to resave frame 0
-  for i, stack in ipairs(self.engine.stacks) do
-    stack:saveForRollback()
-  end
-end
-
 ---@param prefix "I" | "U"
 ---@param input string
 function ClientMatch:receiveInput(prefix, input)

--- a/client/src/ClientStack.lua
+++ b/client/src/ClientStack.lua
@@ -53,9 +53,7 @@ function(self, args)
   self.player_number = args.player_number or args.engine.which
   self.is_local = args.player and args.player.isLocal or args.engine.is_local
   self.character = characters[args.characterId]
-  if self.character and not self.character.fullyLoaded then
-    ModController:loadModFor(self.character, self, true)
-  end
+  ModController:loadModFor(self.character, self)
   self.theme = args.theme or themes[config.theme]
 
   self.panels_dir = args.panels_dir
@@ -513,6 +511,7 @@ function ClientStack:assignAssets(assetPack)
 end
 
 function ClientStack:deinit()
+  ModController:releaseModsFor(self)
   GraphicsUtil:releaseQuad(self.healthQuad)
   GraphicsUtil:releaseQuad(self.multi_prestopQuad)
   GraphicsUtil:releaseQuad(self.multi_stopQuad)

--- a/client/src/MatchParticipant.lua
+++ b/client/src/MatchParticipant.lua
@@ -15,6 +15,7 @@ local ModController = require("client.src.mods.ModController")
 ---@field panelId string id of the panelSet used to source shock garbage images
 ---@field wantsReady boolean
 ---@field attackEngineSettings table
+---@field lockCharacterAndStage boolean? if true, prevents character and stage from being refreshed between matches
 
 ---@class MatchParticipant
 ---@field name string the name of the participant for display
@@ -197,7 +198,7 @@ function MatchParticipant:onMatchEnded()
     self:setWantsReady(false)
    end
   -- Skip refresh if character and stage are locked (e.g., in puzzle mode)
-  if not self.lockCharacterAndStage then
+  if not self.settings.lockCharacterAndStage then
     self:refreshCharacter()
     self:refreshStage()
   end

--- a/client/src/MatchParticipant.lua
+++ b/client/src/MatchParticipant.lua
@@ -196,8 +196,11 @@ function MatchParticipant:onMatchEnded()
    if self.human then
     self:setWantsReady(false)
    end
-  self:refreshCharacter()
-  self:refreshStage()
+  -- Skip refresh if character and stage are locked (e.g., in puzzle mode)
+  if not self.lockCharacterAndStage then
+    self:refreshCharacter()
+    self:refreshStage()
+  end
 end
 
 function MatchParticipant:isHuman()

--- a/client/src/scenes/GameBase.lua
+++ b/client/src/scenes/GameBase.lua
@@ -253,6 +253,17 @@ function GameBase:setupGameOver()
     SoundController:fadeOutActiveTrack(3)
   end
 
+  local winners = self.match:getWinners()
+  if self.text == nil then
+    if #self.match.players == 1 then
+      self.text = loc("pl_gameover")
+    elseif #winners == 1 then
+      self.text = loc("ss_p_wins", winners[1].name)
+    else
+      self.text = loc("ss_draw")
+    end
+  end
+  
   self:customGameOverSetup()
 end
 
@@ -451,16 +462,9 @@ end
 function GameBase:drawEndGameText()
   if self.match.ended then
 
-    local winners = self.match:getWinners()
     local message = self.text
     if message == nil then
-      if #self.match.players == 1 then
-        message = loc("pl_gameover")
-      elseif #winners == 1 then
-        message = loc("ss_p_wins", winners[1].name)
-      else
-        message = loc("ss_draw")
-      end
+      message = ""
     end
 
     local gameOverPosition = themes[config.theme].gameover_text_Pos

--- a/client/src/scenes/PuzzleGame.lua
+++ b/client/src/scenes/PuzzleGame.lua
@@ -3,6 +3,7 @@ local class = require("common.lib.class")
 local tableUtils = require("common.lib.tableUtils")
 local InputCompression = require("common.data.InputCompression")
 local KeyDataEncoding = require("common.data.KeyDataEncoding")
+local LevelPresets = require("common.data.LevelPresets")
 local consts = require("common.engine.consts")
 local PuzzleHierarchyDisplay = require("client.src.graphics.PuzzleHierarchyDisplay")
 local PuzzleGoalDisplay = require("client.src.graphics.PuzzleGoalDisplay")
@@ -40,6 +41,15 @@ local PuzzleGame = class(
     self.puzzleSet = sceneParams.puzzleSet
     self.puzzleSetIterator = sceneParams.puzzleSetIterator
 
+    -- Pick up queued solution inputs if passed from previous scene
+    if sceneParams.queuedSolutionInputs then
+      self.queuedInputs = sceneParams.queuedSolutionInputs
+      self.hintUsed = sceneParams.hintWasUsed or false
+      -- Clear from battleRoom parameters so it doesn't persist
+      GAME.battleRoom.sceneParameters.queuedSolutionInputs = nil
+      GAME.battleRoom.sceneParameters.hintWasUsed = nil
+    end
+
     local indices = deepcpy(self.puzzleSetIterator:currentPuzzle())
     local index = indices[#indices]
     indices[#indices] = nil
@@ -75,9 +85,6 @@ function PuzzleGame:getCurrentPuzzle()
 end
 
 function PuzzleGame.setupNextPuzzle(battleRoom, puzzleSetIterator, puzzleSet, advance)
-  -- Store current stage info for potential preservation
-  local currentStageId = battleRoom.match and battleRoom.match.stageId or nil
-  
   -- Get puzzle indices - either advance to next or stay on current
   local puzzleIndices
   if advance == false then
@@ -85,13 +92,12 @@ function PuzzleGame.setupNextPuzzle(battleRoom, puzzleSetIterator, puzzleSet, ad
   else
     puzzleIndices = puzzleSetIterator:nextPuzzle()
   end
-  
+
   if puzzleIndices then
     local puzzle = PuzzleSetIterator.getPuzzleFromIndices(puzzleSet, puzzleIndices)
     if puzzle then
       GAME.battleRoom:setGameMode(puzzle:toGameMode())
       GAME.battleRoom.panelSource = puzzle:toPanelSource(config.puzzle_randomColors)
-      battleRoom.preferredStageId = currentStageId
     end
   end
   return puzzleIndices
@@ -102,7 +108,15 @@ function PuzzleGame:customLoad()
 ---@diagnostic disable-next-line: assign-type-mismatch
   self.player = self.match.players[1]
   self.inputConfiguration = self.player.inputConfiguration
-  
+
+  -- Restore level if it was temporarily changed for solution playback
+  if GAME.battleRoom.sceneParameters.restoreLevelAfterCreation then
+    local restoreLevel = GAME.battleRoom.sceneParameters.restoreLevelAfterCreation
+    GAME.localPlayer:setLevel(restoreLevel)
+    GAME.localPlayer:setLevelData(LevelPresets.getModern(restoreLevel))
+    GAME.battleRoom.sceneParameters.restoreLevelAfterCreation = nil
+  end
+
   -- Override drawTimer to prevent elapsed time display in puzzles
   self.match.drawTimer = function() end
   
@@ -178,6 +192,11 @@ function PuzzleGame:customLoad()
       puzzleGame = self
     })
     self.uiRoot:addChild(self.puzzleHelpDisplay)
+
+    -- If solution is playing (non-move puzzle with hint used), show the hint state
+    if self.hintUsed and currentPuzzle.puzzleType ~= "moves" then
+      self.puzzleHelpDisplay:transitionToState("hint_shown")
+    end
   end
 end
 
@@ -234,14 +253,16 @@ function PuzzleGame:readyToProceedToNextScene()
 end
 
 function PuzzleGame:startNextScene()
-  if self.match.engine.aborted then
+  local shouldPop = self.match.engine.aborted or not self.puzzleSetIterator
+
+  if shouldPop then
+    -- Clear the character/stage lock when returning to puzzle menu
+    if self.player then
+      self.player.lockCharacterAndStage = nil
+    end
     GAME.navigationStack:pop()
   else
-    if self.puzzleSetIterator then
-      self.player:setWantsReady(true)
-    else
-      GAME.navigationStack:pop()
-    end
+    self.player:setWantsReady(true)
   end
 end
 
@@ -259,7 +280,12 @@ function PuzzleGame:recordPuzzleSolution()
     -- Don't overwrite existing solutions
     return
   end
-  
+
+  -- Only record solutions when playing at level 10
+  if GAME.localPlayer.settings.level ~= 10 then
+    return
+  end
+
   local engine = self.match.players[1].stack.engine
   if engine.inputMethod ~= "controller" then
     return
@@ -297,12 +323,26 @@ function PuzzleGame:recordPuzzleSolution()
   end
 end
 
+function PuzzleGame:drawEndGameText()
+  if self.isResetting or self.hintUsed then
+    return
+  end
+
+  -- Call parent implementation first
+  GameBase.drawEndGameText(self)
+end
+
 function PuzzleGame:customGameOverSetup()
+  if self.isResetting then
+    self.text = nil
+    return
+  end
+
   if self.match.stacks[1].engine.game_over_clock <= 0 and not self.match.engine.aborted then -- puzzle has been solved successfully
     self.text = loc("pl_you_win")
     self:savePuzzleRecordResult(not self.hintUsed)
     self:recordPuzzleSolution()
-    
+
     -- If hint/solution was used, stay on the same puzzle; otherwise advance to next
     local puzzleIndices = PuzzleGame.setupNextPuzzle(GAME.battleRoom, self.puzzleSetIterator, self.puzzleSet, not self.hintUsed)
     if puzzleIndices then
@@ -318,7 +358,11 @@ function PuzzleGame:customGameOverSetup()
 end
 
 function PuzzleGame:drawHUD()
-  -- HUD elements are drawn via normal element heirarchy in puzzle game
+  -- HUD elements are drawn via normal element hierarchy in puzzle game
+  -- Draw level display
+  if not self.match.isPaused and self.match.stacks[1] then
+    self.match.stacks[1]:drawLevel()
+  end
 end
 
 function PuzzleGame:drawBackground()
@@ -373,11 +417,27 @@ end
 
 function PuzzleGame:resetPuzzle()
   self:savePuzzleRecordResult(false)
-  self.match:resetPuzzle()
-  if self.puzzleHelpDisplay then
-    self.puzzleHelpDisplay.playerSwapPositions = {}
+
+  -- Mark that we're resetting to avoid showing "you lose" text
+  self.isResetting = true
+
+  -- Abort the current match to properly end it and reset BattleRoom state to Setup
+  self.match:abort()
+
+  -- Setup the puzzle (same as losing does in customGameOverSetup)
+  PuzzleGame.setupNextPuzzle(GAME.battleRoom, self.puzzleSetIterator, self.puzzleSet, false)
+
+  GAME.battleRoom.sceneParameters.useInstantTransition = true
+
+  -- Re-claim the player's last used input configuration before setting ready
+  -- This is needed because onMatchEnded unrestricted inputs, and setWantsReady
+  -- requires an input to be actively pressed to claim, which may not be the case
+  if self.player.lastUsedInputConfiguration then
+    self.player:restrictInputs(self.player.lastUsedInputConfiguration)
   end
-  self.hintUsed = false
+
+  -- Trigger new match creation (same as startNextScene does after game over)
+  self.player:setWantsReady(true)
 end
 
 -- Execute a single hint (position cursor and swap)
@@ -443,11 +503,25 @@ function PuzzleGame:playPuzzleSolution(solutionInputs)
   if not self.match.stacks[1] or not self.match.stacks[1].engine then
     return false
   end
-  
+
+  local currentPuzzle = self:getCurrentPuzzle()
+  local isMovePuzzle = currentPuzzle and currentPuzzle.puzzleType == "moves"
+
+  -- Store solution inputs for the new scene to pick up
+  GAME.battleRoom.sceneParameters.queuedSolutionInputs = procat(solutionInputs)
+  GAME.battleRoom.sceneParameters.hintWasUsed = true
+
+  -- For non-move puzzles, temporarily set to level 10 for faster panels
+  -- Store the original level to restore after match is created
+  if not isMovePuzzle then
+    GAME.battleRoom.sceneParameters.restoreLevelAfterCreation = config.puzzle_level
+    GAME.localPlayer:setLevel(10)
+    GAME.localPlayer:setLevelData(LevelPresets.getModern(10))
+  end
+
+  -- Reset puzzle (creates new scene via resetPuzzle)
   self:resetPuzzle()
-  self.hintUsed = true
-  self:queueInputs(procat(solutionInputs))
-  
+
   return true
 end
 

--- a/client/src/scenes/PuzzleGame.lua
+++ b/client/src/scenes/PuzzleGame.lua
@@ -258,7 +258,7 @@ function PuzzleGame:startNextScene()
   if shouldPop then
     -- Clear the character/stage lock when returning to puzzle menu
     if self.player then
-      self.player.lockCharacterAndStage = nil
+      self.player.settings.lockCharacterAndStage = nil
     end
     GAME.navigationStack:pop()
   else

--- a/client/src/scenes/PuzzleMenu.lua
+++ b/client/src/scenes/PuzzleMenu.lua
@@ -74,8 +74,16 @@ end
 
 function PuzzleMenu:startGame(puzzleSet, puzzleSetIterator)
   assert(puzzleSetIterator)
-  self:setupPuzzleSetForStartGame(puzzleSet, puzzleSetIterator)
+  GAME.localPlayer:setLevel(config.puzzle_level)
+  GAME.localPlayer:setLevelData(LevelPresets.getModern(config.puzzle_level))
+
   local player = self.battleRoom.players[1]
+
+  -- Lock character and stage for the entire puzzle session
+  -- This prevents them from changing between puzzles
+  player.lockCharacterAndStage = true
+
+  self:setupPuzzleSetForStartGame(puzzleSet, puzzleSetIterator)
   player:setWantsReady(true)
   GAME.theme:playValidationSfx()
 end
@@ -117,8 +125,6 @@ function PuzzleMenu:load(sceneParams)
       onValueChange = function(s)
         GAME.theme:playMoveSfx()
         config.puzzle_level = s.value
-        GAME.localPlayer:setLevel(s.value)
-        GAME.localPlayer:setLevelData(LevelPresets.getModern(s.value))
       end
     })
 
@@ -673,7 +679,7 @@ function PuzzleMenu:getDisplayStack(puzzle)
   local gameMode = puzzle:toGameMode()
   local args = {
     which = 1,
-    levelData = LevelPresets.getModern(config.puzzle_level or 5),
+    levelData = LevelPresets.getModern(config.puzzle_level),
     is_local = false,
     stackOverConditions = gameMode.matchRules.stackOverConditions,
     stackWinConditions = gameMode.matchRules.stackWinConditions,

--- a/client/src/scenes/PuzzleMenu.lua
+++ b/client/src/scenes/PuzzleMenu.lua
@@ -81,7 +81,17 @@ function PuzzleMenu:startGame(puzzleSet, puzzleSetIterator)
 
   -- Lock character and stage for the entire puzzle session
   -- This prevents them from changing between puzzles
-  player.lockCharacterAndStage = true
+  player.settings.lockCharacterAndStage = true
+
+  -- Use the resolved stage for all matches in this session
+  self.battleRoom.preferredStageId = player.settings.stageId
+
+  -- Refresh to set characterId/stageId and emit signals for loading
+  player:refreshCharacter()
+  player:refreshStage()
+
+  -- Update loading state to ensure BattleRoom knows assets need to load
+  self.battleRoom:updateLoadingState()
 
   self:setupPuzzleSetForStartGame(puzzleSet, puzzleSetIterator)
   player:setWantsReady(true)

--- a/client/src/ui/StackElement.lua
+++ b/client/src/ui/StackElement.lua
@@ -18,6 +18,10 @@ UiElement)
 
 ---@param stack PlayerStack?
 function StackElement:setStack(stack)
+  if self.stack then
+    self.stack:deinit()
+  end
+  
   self.stack = stack
   if self.stack then
     self.stack.gfxScale = self.scale


### PR DESCRIPTION
Main problem was that solutions needed level 10, but you can play on other levels
Reset the puzzle on level 10 by loading a new puzzlegame scene and then bringing the level back afterwards
This exposed some other problems I fixed:
- Add a way to have an instant transition to avoid jarring
- Cleanup the way the win / lose text is calculated so we can hide it on reset
- delete hacky rollback way of resetting
- add way to pass on queued inputs to next puzzle game scene
- don't save solutions for non level 10
- Draw level in puzzles so you know what difficulty your on
- had to reclaim input when going to next puzzle because the game "aborted"
- Make sure we load and release mods right for puzzles