### PR TITLE
Enable warnings on unopened files so they aren't hidden

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -15,26 +15,54 @@
         "jit",
         "lldebugger",
         "config",
-        "DEBUG_ENABLED"
+        "DEBUG_ENABLED",
+        "seed_from_mt", // TODO: Remove once this global is gone
+        "extract_mt", // TODO: Remove once this global is gone
+        "cs_random", // TODO: Remove once this global is gone
+        "initialize_mt_generator" // TODO: Remove once this global is gone
     ],
-    "diagnostics.ignoredFiles": "Opened",
+    "diagnostics.libraryFiles": "Disable", // We don't want to diagnose library files, we shouldn't be editing them for the most part
+    "diagnostics.ignoredFiles": "Disable", // We don't want to diagnose ignored files, we ignored them for a reason
+    "diagnostics.neededFileStatus": {
+        "assign-type-mismatch": "Opened", // TODO: Remove once all warnings are fixed
+        "cast-local-type": "Opened", // TODO: Remove once all warnings are fixed
+        "code-after-break": "Any",
+        "duplicate-set-field": "Any",
+        "empty-block": "Any",
+        "inject-field": "Any",
+        "need-check-nil": "Opened", // TODO: Remove once all warnings are fixed
+        "param-type-mismatch": "Opened", // TODO: Remove once all warnings are fixed
+        "redefined-local": "Any",
+        "redundant-return": "Any",
+        "return-type-mismatch": "Any",
+        "trailing-space": "Any",
+        "undefined-field": "Opened", // TODO: Remove once all warnings are fixed
+        "unreachable-code": "Any",
+        "unused-function": "Any",
+        "unused-label": "Any",
+        "unused-local": "Any",
+        "unused-vararg": "Any",
+        "undefined-doc-name": "Opened" // TODO: Remove once all warnings are fixed
+    },
 
     "hint.semicolon": "Disable",
 
     "workspace.checkThirdParty": false,
     "workspace.ignoreDir": [
+        "client/lib/rich_presence/",
         ".vscode",
         // these would flag duplicate functions otherwise as they also define love callbacks
+        // TODO: We should probably just ignore those spots in the files so we get other check still
         "testLauncher.lua",
         "verificationLauncher.lua",
         // may want to include this to debug updater features
-        "updater"
+        "updater",
+        "common/lib/socket.lua",
+        "common/lib/dkjson.lua",
+        "common/lib/csprng.lua"
     ],
     "workspace.library": [
         "${3rd}/love2d/library",
-        "common/lib/socket.lua",
-        "common/lib/dkjson.lua",
-        "common/lib/csprng.lua",
         ".vscode/love2d-12/library"
     ]
 }

--- a/.luarc.json
+++ b/.luarc.json
@@ -35,7 +35,7 @@
         "redefined-local": "Any",
         "redundant-return": "Any",
         "return-type-mismatch": "Any",
-        "trailing-space": "Any",
+        "trailing-space": "None", // Just noise, we don't particularly care
         "undefined-field": "Opened", // TODO: Remove once all warnings are fixed
         "unreachable-code": "Any",
         "unused-function": "Any",

--- a/.luarc.json
+++ b/.luarc.json
@@ -34,6 +34,7 @@
         "${3rd}/love2d/library",
         "common/lib/socket.lua",
         "common/lib/dkjson.lua",
-        "common/lib/csprng.lua"
+        "common/lib/csprng.lua",
+        ".vscode/love2d-12/library"
     ]
 }

--- a/client/src/BattleRoom.lua
+++ b/client/src/BattleRoom.lua
@@ -30,6 +30,7 @@ local GeneratorSource = require("common.engine.GeneratorSource")
 ---@field match ClientMatch
 ---@field panelSource table?
 ---@field sceneParameters table?
+---@field preferredStageId string? id of the stage the battle room prefers
 ---@overload fun(mode: GameMode, gameScene: table?): BattleRoom
 BattleRoom = class(
 function(self, mode, gameScene)

--- a/client/src/ClientMatch.lua
+++ b/client/src/ClientMatch.lua
@@ -76,6 +76,7 @@ function ClientMatch.createFromBattleRoom(battleRoom)
 end
 
 ---@param gameMode GameMode
+---@return ClientMatch
 function ClientMatch.createFromGameMode(players, gameMode, panelSource, ranked, stageId)
   local clientMatch = ClientMatch(players, ranked)
   clientMatch:setStage(stageId)

--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -57,6 +57,9 @@ end
 ---@field lastReplayPath string?
 ---@field crashTrace string?
 ---@field theme Theme
+---@field focused boolean
+---@field connected_server_ip string?
+---@field connected_server_port integer?
 ---@overload fun(): PanelAttack
 local Game = class(
   function(self)

--- a/client/src/PuzzleSet.lua
+++ b/client/src/PuzzleSet.lua
@@ -329,7 +329,7 @@ function PuzzleSet:getPuzzleFromIndices(puzzleSetIndices, puzzleIndex)
   local puzzleSet = self:getPuzzleSetFromIndices(puzzleSetIndices)
   
   -- Get the final puzzle
-  if puzzleSet.puzzles and puzzleSet.puzzles[puzzleIndex] then
+  if puzzleSet and puzzleSet.puzzles and puzzleSet.puzzles[puzzleIndex] then
     return puzzleSet.puzzles[puzzleIndex]
   end
   

--- a/client/src/PuzzleSetIterator.lua
+++ b/client/src/PuzzleSetIterator.lua
@@ -123,7 +123,7 @@ end
 
 ---Static method to get puzzle from puzzle set using puzzleSetIndices
 ---@param puzzleSet PuzzleSet
----@param puzzleSetIndices integer[]
+---@param puzzleSetIndices integer[]?
 ---@return Puzzle?
 function PuzzleSetIterator.getPuzzleFromIndices(puzzleSet, puzzleSetIndices)
   if puzzleSetIndices == nil then

--- a/client/src/mods/Character.lua
+++ b/client/src/mods/Character.lua
@@ -27,12 +27,15 @@ local chainStyle = {classic = 0, per_chain = 1}
 ---@enum ComboStyle
 local comboStyle = {classic = 0, per_combo = 1}
 
+---@alias TelegraphImageRow table<integer, love.Texture?>
+---@alias TelegraphImageMap table<integer|string, TelegraphImageRow | love.Texture?>
+
 ---@class Character:Mod
 ---@field display_name string Name for display in selection menus
 ---@field stage string? Id of a stage for super select
 ---@field panels string? Id of a panel set for super select
 ---@field images table<string, love.Texture> graphical assets of the character
----@field telegraph_garbage_images userdata[][] graphical assets for telegraph display
+---@field telegraph_garbage_images TelegraphImageMap graphical assets for telegraph display
 ---@field sounds table<string, table<integer, SfxGroup> | SfxGroup> sound effect assets of the character
 ---@field musics table<string, Music> music assets of the character
 ---@field hasMusic boolean? if the character has any music

--- a/client/src/mods/CharacterLoader.lua
+++ b/client/src/mods/CharacterLoader.lua
@@ -6,7 +6,8 @@ local ModLoader = require("client.src.mods.ModLoader")
 
 local CharacterLoader = {}
 
--- (re)Initializes the characters globals with data
+---(re)Initializes the characters globals with data
+---@return nil
 function CharacterLoader.initCharacters()
   local all, ids, filtered, visible = ModLoader.initMods(Character)
   ---@type table<string, Character>
@@ -21,6 +22,8 @@ function CharacterLoader.initCharacters()
   CharacterLoader.loadBundleIcons()
 end
 
+---Ensures all characters have an icon, generating bundle icons when required
+---@return nil
 function CharacterLoader.loadBundleIcons()
   -- bundles without character icon display up to 4 icons of their subcharacters
   -- there is no guarantee the subcharacters had been loaded previously so do it after everything got preloaded
@@ -35,6 +38,9 @@ function CharacterLoader.loadBundleIcons()
   end
 end
 
+---Resolves a requested character selection, falling back to a random visible character
+---@param characterId string|nil
+---@return string
 function CharacterLoader.resolveCharacterSelection(characterId)
   if not characterId or not characters[characterId] then
     -- resolve via random selection
@@ -44,6 +50,9 @@ function CharacterLoader.resolveCharacterSelection(characterId)
   return characterId
 end
 
+---Resolves bundle selections until a concrete character is chosen
+---@param characterId string
+---@return string
 function CharacterLoader.resolveBundle(characterId)
   while characters[characterId]:isBundle() do
     local subMods = characters[characterId]:getSubMods()
@@ -53,6 +62,9 @@ function CharacterLoader.resolveBundle(characterId)
   return characterId
 end
 
+---Fully resolves a potentially missing or bundled character selection
+---@param characterId string|nil
+---@return string
 function CharacterLoader.fullyResolveCharacterSelection(characterId)
   characterId = CharacterLoader.resolveCharacterSelection(characterId)
   return CharacterLoader.resolveBundle(characterId)

--- a/client/src/scenes/PuzzleEditorScene.lua
+++ b/client/src/scenes/PuzzleEditorScene.lua
@@ -706,8 +706,12 @@ function PuzzleEditorScene:savePuzzle()
   assert(self.rootPuzzleSet.fileSource)
 
   local targetPuzzleSet = self.rootPuzzleSet
+  ---@cast targetPuzzleSet PuzzleSet
   for _, pathIndex in ipairs(self.puzzleSetPath) do
-    targetPuzzleSet = targetPuzzleSet.puzzleSets[pathIndex]
+    local nextSet = targetPuzzleSet.puzzleSets[pathIndex]
+    assert(nextSet)
+    ---@cast nextSet PuzzleSet
+    targetPuzzleSet = nextSet
   end
 
   targetPuzzleSet:updatePuzzle(self.puzzleIndex, updatedPuzzle)

--- a/client/src/scenes/PuzzleEditorScene.lua
+++ b/client/src/scenes/PuzzleEditorScene.lua
@@ -66,6 +66,7 @@ function PuzzleEditorScene:customLoad()
     end
 
     -- Initialize garbage ID counter from stack's garbageCreatedCount to avoid ID collisions
+    ---@diagnostic disable-next-line: invisible
     self.garbageIdCounter = self.match.stacks[1].engine.garbageCreatedCount
   end
 

--- a/client/src/scenes/PuzzleEditorScene.lua
+++ b/client/src/scenes/PuzzleEditorScene.lua
@@ -16,7 +16,7 @@ local directsFocus = require("client.src.ui.FocusDirector")
 ---@field puzzleIndex integer
 ---@field originalPuzzle Puzzle
 ---@field rootPuzzleSet PuzzleSet?
----@field puzzleSetPath table<integer>?
+---@field puzzleSetPath table<integer>
 ---@field selectedPanelType integer
 ---@field cursorMode boolean
 ---@field isEditing boolean
@@ -58,7 +58,7 @@ function PuzzleEditorScene:customLoad()
 
   if self.match.stacks[1] then
     self.match.stacks[1].engine.do_countdown = true
-    
+
     -- Initialize cursor position from puzzle if set
     if self.originalPuzzle.cursorStartLeft then
       self.match.stacks[1].engine.cur_row = self.originalPuzzle.cursorStartLeft.row
@@ -151,14 +151,14 @@ function PuzzleEditorScene:createPaletteButtons()
   local buttonSize = 40
   local spacing = 10
   local buttonsPerRow = 3
-  
+
   for i, color in ipairs(colors) do
     local row = math.floor((i - 1) / buttonsPerRow)
     local col = (i - 1) % buttonsPerRow
-    
+
     local x = col * (buttonSize + spacing)
     local y = row * (buttonSize + spacing)
-    
+
     local button = self:createPanelButtonSmall(color, buttonSize)
     button.x = x
     button.y = y
@@ -175,14 +175,14 @@ function PuzzleEditorScene:createPaletteButtons()
   local cursorIndex = #colors + 1
   local row = math.floor((cursorIndex - 1) / buttonsPerRow)
   local col = (cursorIndex - 1) % buttonsPerRow
-  
+
   local x = col * (buttonSize + spacing)
   local y = row * (buttonSize + spacing)
-  
+
   local cursorButton = self:createCursorButton(buttonSize)
   cursorButton.x = x
   cursorButton.y = y
-  
+
   self.paletteButtons[cursorIndex] = {button = cursorButton, color = "cursor"}
   palettePanel:addChild(cursorButton)
 
@@ -190,14 +190,14 @@ function PuzzleEditorScene:createPaletteButtons()
   local garbageIndex = cursorIndex + 1
   row = math.floor((garbageIndex - 1) / buttonsPerRow)
   col = (garbageIndex - 1) % buttonsPerRow
-  
+
   x = col * (buttonSize + spacing)
   y = row * (buttonSize + spacing)
-  
+
   local garbageButton = self:createGarbageButton(buttonSize)
   garbageButton.x = x
   garbageButton.y = y
-  
+
   self.paletteButtons[garbageIndex] = {button = garbageButton, color = "garbage"}
   palettePanel:addChild(garbageButton)
 
@@ -205,14 +205,14 @@ function PuzzleEditorScene:createPaletteButtons()
   local shockGarbageIndex = garbageIndex + 1
   row = math.floor((shockGarbageIndex - 1) / buttonsPerRow)
   col = (shockGarbageIndex - 1) % buttonsPerRow
-  
+
   x = col * (buttonSize + spacing)
   y = row * (buttonSize + spacing)
-  
+
   local shockGarbageButton = self:createShockGarbageButton(buttonSize)
   shockGarbageButton.x = x
   shockGarbageButton.y = y
-  
+
   self.paletteButtons[shockGarbageIndex] = {button = shockGarbageButton, color = "shock_garbage"}
   palettePanel:addChild(shockGarbageButton)
 
@@ -221,7 +221,7 @@ end
 
 function PuzzleEditorScene:updatePaletteSelection()
   for _, paletteButton in ipairs(self.paletteButtons) do
-    if (paletteButton.color == self.selectedPanelType and not self.cursorMode and not self.garbageMode and not self.shockGarbageMode) or 
+    if (paletteButton.color == self.selectedPanelType and not self.cursorMode and not self.garbageMode and not self.shockGarbageMode) or
        (paletteButton.color == "cursor" and self.cursorMode) or
        (paletteButton.color == "garbage" and self.garbageMode) or
        (paletteButton.color == "shock_garbage" and self.shockGarbageMode) then
@@ -318,7 +318,7 @@ function PuzzleEditorScene:createPanelButtonSmall(color, size)
     -- Colorless panel - use the actual panel image
     local stack = self.match.stacks[1]
     local panelsData = panels[stack.panels_dir]
-    
+
     return ui.ImageButton({
       image = panelsData.greyPanel,
       width = size,
@@ -337,7 +337,7 @@ function PuzzleEditorScene:createPanelButtonSmall(color, size)
     local stack = self.match.stacks[1]
     local panelsData = panels[stack.panels_dir]
     local panelImage = panelsData.displayIcons[color]
-    
+
     return ui.ImageButton({
       image = panelImage,
       width = size,
@@ -356,7 +356,7 @@ end
 
 function PuzzleEditorScene:createCursorButton(size)
   local cursorImage = GAME.theme.images.cursor[1].image
-  
+
   return ui.ImageButton({
     image = cursorImage,
     width = size,
@@ -374,7 +374,7 @@ end
 function PuzzleEditorScene:createGarbageButton(size)
   local stack = self.match.stacks[1]
   local garbageImage = stack.character.images.pop
-  
+
   return ui.ImageButton({
     image = garbageImage,
     width = size,
@@ -392,38 +392,38 @@ end
 function PuzzleEditorScene:createShockGarbageButton(size)
   local stack = self.match.stacks[1]
   local panelsData = panels[stack.panels_dir]
-  
+
   -- Create a canvas to draw the shock garbage with end caps like it appears in game
   local canvas = love.graphics.newCanvas(size, size)
   local prevCanvas = love.graphics.getCanvas()
-  
+
   canvas:renderTo(function()
     local shockImages = panelsData.images.metals
     local leftImage = shockImages.left
     local midImage = shockImages.mid
     local rightImage = shockImages.right
-    
+
     -- Calculate scaling to fit the button size
     local targetWidth = size * 0.8  -- Leave some padding
     local targetHeight = size * 0.6
-    
+
     -- Draw left cap
     local leftWidth = targetWidth * 0.25
     love.graphics.draw(leftImage, size * 0.1, size * 0.2, 0, leftWidth / leftImage:getWidth(), targetHeight / leftImage:getHeight())
-    
+
     -- Draw middle section
     local midWidth = targetWidth * 0.5
     local midX = size * 0.1 + leftWidth
     love.graphics.draw(midImage, midX, size * 0.2, 0, midWidth / midImage:getWidth(), targetHeight / midImage:getHeight())
-    
+
     -- Draw right cap
     local rightWidth = targetWidth * 0.25
     local rightX = midX + midWidth
     love.graphics.draw(rightImage, rightX, size * 0.2, 0, rightWidth / rightImage:getWidth(), targetHeight / rightImage:getHeight())
   end)
-  
+
   love.graphics.setCanvas(prevCanvas)
-  
+
   return ui.ImageButton({
     image = canvas,
     width = size,
@@ -492,14 +492,14 @@ end
 function PuzzleEditorScene:clearGarbageBlock(row, column)
   local stack = self.match.stacks[1]
   local panel = stack.engine.panels[row][column]
-  
+
   -- If this panel is not garbage, nothing to clear
   if not panel.isGarbage then
     return
   end
-  
+
   local garbageId = panel.garbageId
-  
+
   -- Find and clear all panels with the same garbage ID
   for r = 1, stack.engine.height do
     for c = 1, stack.engine.width do
@@ -530,10 +530,10 @@ function PuzzleEditorScene:placeGarbageBlock()
   local maxRow = math.max(startRow, endRow)
   local minCol = math.min(startCol, endCol)
   local maxCol = math.max(startCol, endCol)
-  
+
   local width = maxCol - minCol + 1
   local height = maxRow - minRow + 1
-  
+
   -- Shock garbage is limited to 1 panel high
   if self.shockGarbageMode and height > 1 then
     -- Keep only the start row for shock garbage
@@ -586,7 +586,7 @@ function PuzzleEditorScene:placeGarbageBlock()
   -- Create garbage block
   self.garbageIdCounter = self.garbageIdCounter + 1
   local garbageId = self.garbageIdCounter
-  
+
   for row = minRow, maxRow do
     for col = minCol, maxCol do
       if row >= 1 and row <= stack.engine.height and col >= 1 and col <= stack.engine.width then
@@ -639,12 +639,12 @@ function PuzzleEditorScene:editPanel(row, column, newColor)
       stack.engine.cur_col = 3
       logger.debug("Cursor start position removed")
     end
-    
+
     if not self.hasUnsavedChanges then
       self.hasUnsavedChanges = true
       self.statusLabel:setText("* Unsaved changes")
     end
-    
+
     -- Stay in cursor mode until user selects a different tool
     return
   end
@@ -711,7 +711,7 @@ function PuzzleEditorScene:savePuzzle()
   end
 
   targetPuzzleSet:updatePuzzle(self.puzzleIndex, updatedPuzzle)
-  
+
   self.rootPuzzleSet:saveTargetPuzzleToFile(targetPuzzleSet, self.puzzleIndex, updatedPuzzle)
 
   self.hasUnsavedChanges = false
@@ -728,20 +728,22 @@ end
 function PuzzleEditorScene:clearSolution()
   -- Clear the solution from the original puzzle
   self.originalPuzzle.solution = nil
-  
+
   -- Mark as having unsaved changes
   if not self.hasUnsavedChanges then
     self.hasUnsavedChanges = true
     self.statusLabel:setText("* Unsaved changes")
   end
-  
+
   logger.debug("Puzzle solution cleared")
 end
 
 function PuzzleEditorScene:exitEditor()
   -- Clean up input configuration to prevent double claiming
   if self.match and self.match.stacks[1] and self.match.stacks[1].player then
-    self.match.stacks[1].player:unrestrictInputs()
+    local player = self.match.stacks[1].player
+    ---@cast player Player
+    player:unrestrictInputs()
   end
   GAME.navigationStack:pop()
 end

--- a/client/src/scenes/PuzzleGame.lua
+++ b/client/src/scenes/PuzzleGame.lua
@@ -26,6 +26,7 @@ local MultibarElement = require("client.src.ui.MultibarElement")
 ---@field inputQueueIndex integer Current position in the input queue
 ---@field hintUsed boolean Whether a hint has been used for this puzzle
 ---@field multibarElement MultibarElement? Relative multibar component
+---@field playerStack PlayerStack? Player stack associated with the current puzzle run
 local PuzzleGame = class(
   function (self, sceneParams)
     self.keepMusic = true
@@ -99,15 +100,20 @@ end
 
 function PuzzleGame:customLoad()
   -- we cache the player's input configuration here so that only inputs from this config can start the next puzzle
----@diagnostic disable-next-line: assign-type-mismatch
-  self.player = self.match.players[1]
+  local firstPlayer = self.match.players[1]
+  assert(firstPlayer, "PuzzleGame requires a player")
+  assert(firstPlayer.human, "PuzzleGame expects a human-controlled player")
+  ---@cast firstPlayer Player
+  self.player = firstPlayer
   self.inputConfiguration = self.player.inputConfiguration
+  local playerStack = self.player.stack
+  assert(playerStack, "PuzzleGame requires an associated player stack")
+  self.playerStack = playerStack
   
   -- Override drawTimer to prevent elapsed time display in puzzles
   self.match.drawTimer = function() end
   
-  local stack = self.match.stacks[1]
-  assert(stack)
+  local stack = playerStack
 
   stack:moveToCenterPosition()
   
@@ -154,8 +160,9 @@ function PuzzleGame:customLoad()
   end)
   
   local currentPuzzle = self:getCurrentPuzzle()
-  if currentPuzzle and self.match.stacks[1] and self.match.stacks[1].engine then
-    local stack = self.match.stacks[1]
+  local activeStack = self.playerStack
+  if currentPuzzle and activeStack then
+    local stack = activeStack
     local stackWidth = stack.baseWidth + stack.panelOriginXOffset
     local stackRightEdge = stack.frameOriginX * stack.gfxScale + (stackWidth * stack.gfxScale)
     
@@ -246,7 +253,11 @@ function PuzzleGame:startNextScene()
 end
 
 function PuzzleGame:savePuzzleRecordResult(success)
-  local inputs = InputCompression.compressInputString(table.concat(self.match.players[1].stack.engine.confirmedInput))
+  local playerStack = self.playerStack
+  if not playerStack then
+    return
+  end
+  local inputs = InputCompression.compressInputString(table.concat(playerStack.engine.confirmedInput))
   local currentPuzzle = self:getCurrentPuzzle()
   if currentPuzzle then
     GAME.scores:savePuzzleRecord(currentPuzzle, inputs, to_UTC(os.time()), success)
@@ -254,13 +265,18 @@ function PuzzleGame:savePuzzleRecordResult(success)
 end
 
 function PuzzleGame:recordPuzzleSolution()
+  local playerStack = self.playerStack
+  if not playerStack then
+    return
+  end
+
   local currentPuzzle = self:getCurrentPuzzle()
   if not currentPuzzle or currentPuzzle.solution then
     -- Don't overwrite existing solutions
     return
   end
   
-  local engine = self.match.players[1].stack.engine
+  local engine = playerStack.engine
   if engine.inputMethod ~= "controller" then
     return
   end
@@ -273,13 +289,15 @@ function PuzzleGame:recordPuzzleSolution()
   currentPuzzle.solution = inputs
   
   if self.puzzleSetIterator and self.puzzleSet then
+    local puzzleSet = self.puzzleSet
+    ---@cast puzzleSet PuzzleSet
     local currentIndices = self.puzzleSetIterator:currentPuzzle()
     if currentIndices then
       local targetIndices = {unpack(currentIndices)} -- copy the indices
       local puzzleIndex = table.remove(targetIndices) -- remove last element (puzzle index)
       
       -- Find the puzzle set with fileSource and get the adjusted path
-      local sourceRootPuzzleSet, adjustedPath = PuzzleSet.findPuzzleSetWithFileSource(self.puzzleSet, targetIndices)
+      local sourceRootPuzzleSet, adjustedPath = PuzzleSet.findPuzzleSetWithFileSource(puzzleSet, targetIndices)
       
       -- Navigate to the target puzzle set using the adjusted path
       local targetPuzzleSet = sourceRootPuzzleSet
@@ -298,7 +316,8 @@ function PuzzleGame:recordPuzzleSolution()
 end
 
 function PuzzleGame:customGameOverSetup()
-  if self.match.stacks[1].engine.game_over_clock <= 0 and not self.match.engine.aborted then -- puzzle has been solved successfully
+  local playerStack = self.playerStack
+  if playerStack and playerStack.engine.game_over_clock <= 0 and not self.match.engine.aborted then -- puzzle has been solved successfully
     self.text = loc("pl_you_win")
     self:savePuzzleRecordResult(not self.hintUsed)
     self:recordPuzzleSolution()
@@ -335,8 +354,9 @@ end
 
 -- Track player swaps for hint system
 function PuzzleGame:trackSwapInput()
-  if self.puzzleHelpDisplay and self.match.stacks[1] and self.match.stacks[1].engine and not self.match.isPaused then
-    local stack = self.match.stacks[1].engine
+  local playerStack = self.playerStack
+  if self.puzzleHelpDisplay and playerStack and not self.match.isPaused then
+    local stack = playerStack.engine
     local cursorRow = stack.cur_row
     local cursorColumn = stack.cur_col
     self.puzzleHelpDisplay:trackPlayerSwap(cursorRow, cursorColumn)
@@ -345,8 +365,9 @@ end
 
 function PuzzleGame:feedQueuedInput()
   if #self.queuedInputs > 0 and self.inputQueueIndex <= #self.queuedInputs then
-    if self.match.stacks[1] and self.match.stacks[1].engine then
-      local stack = self.match.stacks[1].engine
+    local playerStack = self.playerStack
+    if playerStack then
+      local stack = playerStack.engine
       local input = self.queuedInputs[self.inputQueueIndex]
       stack:receiveConfirmedInput(input)
       self.inputQueueIndex = self.inputQueueIndex + 1
@@ -382,11 +403,12 @@ end
 
 -- Execute a single hint (position cursor and swap)
 function PuzzleGame:executePuzzleHint(targetRow, targetColumn)
-  if not self.match.stacks[1] or not self.match.stacks[1].engine then
+  local playerStack = self.playerStack
+  if not playerStack then
     return false
   end
   
-  local stack = self.match.stacks[1].engine
+  local stack = playerStack.engine
   
   -- Calculate movement needed from current cursor position
   local currentRow = stack.cur_row 
@@ -440,7 +462,7 @@ function PuzzleGame:playPuzzleSolution(solutionInputs)
     return false
   end
   
-  if not self.match.stacks[1] or not self.match.stacks[1].engine then
+  if not self.playerStack then
     return false
   end
   

--- a/client/tests/PuzzleLibraryTests.lua
+++ b/client/tests/PuzzleLibraryTests.lua
@@ -36,6 +36,7 @@ function PuzzleLibraryTests.testCurrentTrainingPuzzleIndicesFilteringAndHistogra
   -- Mock logger to capture debug output for first method only
   local loggedMessages = {}
   local originalDebug = logger.debug
+---@diagnostic disable-next-line: duplicate-set-field
   logger.debug = function(message)
     loggedMessages[#loggedMessages + 1] = message
   end

--- a/client/tests/StackGraphicsTests.lua
+++ b/client/tests/StackGraphicsTests.lua
@@ -18,6 +18,7 @@ local legacyScoreY = 208
 
 ---@param playerCount integer
 ---@param theme table?
+---@return ClientMatch
 local function createEndlessClientMatch(playerCount, theme)
   local endless = GameModes.getPreset("ONE_PLAYER_ENDLESS")
   local players = {}
@@ -195,7 +196,6 @@ test(testNewThemeOffsetPlayer2)
 
 local function testShakeOffsetLargeGarbage()
   local match = createEndlessClientMatch(2, defaultTheme)
-  match.seed = 1
   local stack = match.stacks[2]
   ---@cast stack PlayerStack
 
@@ -289,7 +289,6 @@ test(testShakeOffsetLargeGarbage)
 -- Tests that having reduction properly reduces and rounds
 local function testShakeOffsetReduction()
   local match = createEndlessClientMatch(2, defaultTheme)
-  match.seed = 1
   local stack = match.stacks[2]
   ---@cast stack PlayerStack
   assert(stack:shakeOffsetForShakeFrames(76, 0, 0.5) == 1)
@@ -327,7 +326,6 @@ test(testShakeOffsetReduction)
 
 local function testShakeOffsetMassiveReduction()
   local match = createEndlessClientMatch(2, defaultTheme)
-  match.seed = 1
   local stack = match.stacks[2]
   ---@cast stack PlayerStack
   assert(stack:shakeOffsetForShakeFrames(76, 0, 0.25) == 1)
@@ -365,7 +363,6 @@ test(testShakeOffsetMassiveReduction)
 
 local function testShakeInterpolate()
   local match = createEndlessClientMatch(2, defaultTheme)
-  match.seed = 1
   local stack = match.stacks[2]
   ---@cast stack PlayerStack
   assert(stack:shakeOffsetForShakeFrames(70, 0, 1) == 30)

--- a/common/compatibility/LegacyPanelSource.lua
+++ b/common/compatibility/LegacyPanelSource.lua
@@ -65,20 +65,20 @@ function LegacyPanelSource:generateStartingBoard(stack)
   -- legacy crutch, the arcane magic for the non-uniform starting board assumes this is there and it really doesn't work without it
   ret = string.rep("0", stack.width) .. ret
   -- arcane magic to get a non-uniform starting board
-  ret = procat(ret)
+  local returnArray = procat(ret)
   local maxStartingHeight = 7
   local height = tableUtils.map(procat(string.rep(maxStartingHeight, stack.width)), function(s) return tonumber(s) end)
   local to_remove = 2 * stack.width
   while to_remove > 0 do
     local idx = LegacyPanelGenerator:random(1, stack.width) -- pick a random column
     if height[idx] > 0 then
-      ret[idx + stack.width * (-height[idx] + 8)] = "0" -- delete the topmost panel in this column
+      returnArray[idx + stack.width * (-height[idx] + 8)] = "0" -- delete the topmost panel in this column
       height[idx] = height[idx] - 1
       to_remove = to_remove - 1
     end
   end
 
-  ret = table.concat(ret)
+  ret = table.concat(returnArray)
   ret = string.sub(ret, stack.width + 1)
 
   return ret

--- a/common/data/ReplayV3.lua
+++ b/common/data/ReplayV3.lua
@@ -232,7 +232,9 @@ function ReplayV3.finalizeReplay(match, replay)
     for i, stack in ipairs(match.stacks) do
       if stack.TYPE == "Stack" then
         ---@cast stack Stack
-        replay.stacks[i].inputs = InputCompression.compressInputTable(stack.confirmedInput)
+        local replayCurrentStack = replay.stacks[i]
+        ---@cast replayCurrentStack ReplayStack
+        replayCurrentStack.inputs = InputCompression.compressInputTable(stack.confirmedInput)
       end
     end
 

--- a/common/engine/PuzzleSource.lua
+++ b/common/engine/PuzzleSource.lua
@@ -144,8 +144,10 @@ function PuzzleSource:createPanels(panelBuffer, stack)
       panels[row][column] = panel
 
       local color = string.sub(rowString, column, column)
-      if not garbageStartRow and tonumber(color) then
-        panel.color = tonumber(color)
+      local numericColor = tonumber(color)
+      if not garbageStartRow and numericColor ~= nil then
+        ---@cast numericColor integer
+        panel.color = numericColor
       else
         -- start of a garbage block
         if color == "]" or color == "}" then

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -149,7 +149,7 @@ local DIRECTION_ROW = {up = 1, down = -1, left = 0, right = 0}
 ---@field peak_shake_time integer Records the maximum shake time obtained for the current stretch of uninterrupted shake time. \n
 --- Any additional shake time gained before shake depletes to 0 will reset shake_time back to this value. Set to 0 when shake_time reaches 0.
 ---@field warningsTriggered table ancient ancient, probably remove
----@field game_stopwatch integer? Clock time minus time that swaps were blocked
+---@field game_stopwatch integer Clock time minus time that swaps were blocked
 ---@field rollbackBuffer RollbackBuffer A specialized class to manage memory for rollback data
 ---@field panelTemplate (Panel | fun(row: integer, column: integer, id: integer?): Panel) A template class based on Panel enriched by tailor made closures containing references to the Stack
 ---@field swapStallingBackLog table tracks swaps that will incur a health cost for stalling if not swapping would have resulted in health loss

--- a/common/tests/TestUtils.lua
+++ b/common/tests/TestUtils.lua
@@ -21,7 +21,7 @@ function TestUtils.expectErrorQuiet(thunk, pattern)
   if pattern and not tostring(err):match(pattern) then
     return false, ("unexpected error: %s"):format(err)
   end
-  return true
+  return true, ""
 end
 
 return TestUtils

--- a/common/tests/engine/StackReplayTestingUtils.lua
+++ b/common/tests/engine/StackReplayTestingUtils.lua
@@ -16,6 +16,7 @@ function StackReplayTestingUtils:simulateReplayWithPath(path)
   return self:fullySimulateMatch(match)
 end
 
+---@return Match
 function StackReplayTestingUtils.createEndlessMatch(speed, difficulty, level, playerCount)
   local endless = GameModes.getPreset("ONE_PLAYER_ENDLESS")
   if playerCount == nil then
@@ -44,6 +45,7 @@ function StackReplayTestingUtils.createEndlessMatch(speed, difficulty, level, pl
   return match
 end
 
+---@return Match
 function StackReplayTestingUtils.createSinglePlayerMatch(gameMode, panelSource, inputMethod, levelData)
   if not panelSource then
     local enableShock = (gameMode.stackInteraction ~= GameModes.StackInteractions.NONE)

--- a/common/tests/lib/InputTests.lua
+++ b/common/tests/lib/InputTests.lua
@@ -1,53 +1,59 @@
 local StackReplayTestingUtils = require("common.tests.engine.StackReplayTestingUtils")
 local input = require("client.src.inputManager")
 
-local processEvents = function()
-  if love.event then
-    love.event.pump()
-    for name, a, b, c, d, e, f in love.event.poll() do
-      if name == "quit" then
-        if not love.quit or not love.quit() then
-          return a or 0
-        end
-      end
-      love.handlers[name](a, b, c, d, e, f)
-    end
-  end
-end
+-- NOTE: This test is currently disabled in testLauncher.lua because it requires client love callbacks.
+-- Thus is hasn't been updated to get PlayerStack objects from createEndlessMatch so it was giving annotation warnings
+-- when we update it and fix the warnings we can reenable
 
--- TODO: rewrite the test with sourcing the pressed keys from match.stacks[1].player.inputConfiguration
-local function testSameFrameKeyPressRelease()
-  local match = StackReplayTestingUtils.createEndlessMatch(nil, nil, 10)
-  local player = match.stacks[1].player
-  ---@cast player Player
-  player:restrictInputs(GAME.input.inputConfigurations[1])
-  -- advance past countdown
-  match.stacks[1]:receiveConfirmedInput(string.rep(match.stacks[1]:idleInput(), 200))
-  while match.stacks[1].clock < 200 do
-    assert(not match:hasEnded(), "Game isn't expected to end yet")
-    assert(#match.stacks[1].confirmedInput > match.stacks[1].clock)
-    match:run()
-  end
-  assert(match.stacks[1].clock == 200)
-  -- need local to be true to process input locally
-  match.stacks[1].is_local = true
-  local raiseKey = GAME.input.inputConfigurations[1]["Raise1"]
-  assert(raiseKey ~= nil)
-  love.event.push("keypressed", raiseKey, raiseKey, false)
-  love.event.push("keyreleased", raiseKey, raiseKey, false)
-  processEvents()
-  input:update(1/60)
-  -- there is no way to directly control how many times match will run
-  -- so instead emulate the parts match would run but only once
-  match.stacks[1]:send_controls()
-  match.stacks[1]:run()
-  assert(match.stacks[1].confirmedInput[201] == "g")
-  processEvents()
-  input:update(1/60)
-  match.stacks[1]:send_controls()
-  match.stacks[1]:run()
-  assert(match.stacks[1].confirmedInput[202] == "A")
-  player:unrestrictInputs()
-end
+-- local processEvents = function()
+--   if love.event then
+--     love.event.pump()
+--     for name, a, b, c, d, e, f in love.event.poll() do
+--       if name == "quit" then
+--         if not love.quit or not love.quit() then
+--           return a or 0
+--         end
+--       end
+--       love.handlers[name](a, b, c, d, e, f)
+--     end
+--   end
+-- end
 
-testSameFrameKeyPressRelease()
+-- -- TODO: rewrite the test with sourcing the pressed keys from match.stacks[1].player.inputConfiguration
+-- local function testSameFrameKeyPressRelease()
+--   local match = StackReplayTestingUtils.createEndlessMatch(nil, nil, 10)
+--   local stack = match.stacks[1]
+--   -- Stack instances from Match don't have .player or :send_controls() - these would be added dynamically in client context
+--   ---@type any
+--   local dynamicStack = stack
+--   dynamicStack.player:restrictInputs(GAME.input.inputConfigurations[1])
+--   -- advance past countdown
+--   stack:receiveConfirmedInput(string.rep(stack:idleInput(), 200))
+--   while stack.clock < 200 do
+--     assert(not match:hasEnded(), "Game isn't expected to end yet")
+--     assert(#stack.confirmedInput > stack.clock)
+--     match:run()
+--   end
+--   assert(stack.clock == 200)
+--   -- need local to be true to process input locally
+--   stack.is_local = true
+--   local raiseKey = GAME.input.inputConfigurations[1]["Raise1"]
+--   assert(raiseKey ~= nil)
+--   love.event.push("keypressed", raiseKey, raiseKey, false)
+--   love.event.push("keyreleased", raiseKey, raiseKey, false)
+--   processEvents()
+--   input:update(1/60)
+--   -- there is no way to directly control how many times match will run
+--   -- so instead emulate the parts match would run but only once
+--   dynamicStack:send_controls()
+--   stack:run()
+--   assert(stack.confirmedInput[201] == "g")
+--   processEvents()
+--   input:update(1/60)
+--   dynamicStack:send_controls()
+--   stack:run()
+--   assert(stack.confirmedInput[202] == "A")
+--   dynamicStack.player:unrestrictInputs()
+-- end
+
+-- testSameFrameKeyPressRelease()

--- a/common/tests/lib/InputTests.lua
+++ b/common/tests/lib/InputTests.lua
@@ -18,7 +18,9 @@ end
 -- TODO: rewrite the test with sourcing the pressed keys from match.stacks[1].player.inputConfiguration
 local function testSameFrameKeyPressRelease()
   local match = StackReplayTestingUtils.createEndlessMatch(nil, nil, 10)
-  match.stacks[1].player:restrictInputs(GAME.input.inputConfigurations[1])
+  local player = match.stacks[1].player
+  ---@cast player Player
+  player:restrictInputs(GAME.input.inputConfigurations[1])
   -- advance past countdown
   match.stacks[1]:receiveConfirmedInput(string.rep(match.stacks[1]:idleInput(), 200))
   while match.stacks[1].clock < 200 do
@@ -45,7 +47,7 @@ local function testSameFrameKeyPressRelease()
   match.stacks[1]:send_controls()
   match.stacks[1]:run()
   assert(match.stacks[1].confirmedInput[202] == "A")
-  match.stacks[1].player:unrestrictInputs()
+  player:unrestrictInputs()
 end
 
 testSameFrameKeyPressRelease()

--- a/main.lua
+++ b/main.lua
@@ -387,6 +387,7 @@ function love.errorhandler(msg)
   end
 end
 
+---@diagnostic disable-next-line: duplicate-set-field
 function love.resize(newWidth, newHeight)
   if GAME then
     logger.debug("Updating canvas scale from love.resize")

--- a/server/server.lua
+++ b/server/server.lua
@@ -879,7 +879,7 @@ end
 
 -- gets the bans for that player they did not see yet
 ---@param player ServerPlayer
----@return table<integer, string>
+---@return table<BanID, string>
 function Server:getUnseenBans(player)
   return self.database:getPlayerUnseenBans(player.publicPlayerID)
 end

--- a/testLauncher.lua
+++ b/testLauncher.lua
@@ -134,7 +134,7 @@ function love.update(dt)
     end
     if not success then
       -- Check if the error is due to missing file
-      if string.find(err, "module.*not found") then
+      if err and string.find(err, "module.*not found") then
         logger.error("Test file does not exist: " .. tests[updateCount] .. " - " .. tostring(err))
         logger.error("Make sure the test file exists at the correct path and is properly named")
       else
@@ -179,7 +179,8 @@ function love.errorhandler(msg)
   if lldebugger then
     error(msg, 2)
   else
-    if love.filesystem.exists("test-crash.log") and system.supportsFileBrowserOpen() then
+    local crashInfo = love.filesystem.getInfo("test-crash.log")
+    if crashInfo and system.supportsFileBrowserOpen() then
       local sep = package.config:sub(1, 1)
       love.system.openURL("file://"..love.filesystem.getRealDirectory("test-crash.log") .. sep .. "test-crash.log")
     end


### PR DESCRIPTION
This PR fixes a ton of warnings and starts moving toward warnings always showing, not just on opened files.

The default for some warnings is to only run them on open files
This is confusing but also makes it easy to accidentally add warnings.
I fixed all the types I reasonably could without making tons of changes.
We can enable more as we get more time.

This also disables trailing space as we aren't really getting value from it and it just adds noise.