### PR TITLE
Fix Love File System warning

### DIFF
--- a/client/src/ChallengeMode.lua
+++ b/client/src/ChallengeMode.lua
@@ -6,6 +6,7 @@ local levelPresets = require("common.data.LevelPresets")
 local Game1pChallenge = require("client.src.scenes.Game1pChallenge")
 require("client.src.BattleRoom")
 local save = require("client.src.save")
+local fileUtils = require("client.src.FileUtils")
 
 
 -- Challenge Mode is a particular play through of the challenge mode in the game, it contains all the settings for the mode.
@@ -146,7 +147,7 @@ end
 function ChallengeMode:attackFilePath(difficulty, stageIndex)
   for i = stageIndex, 1, -1 do
     local path = "client/assets/default_data/training/challenge-" .. difficulty .. "-" .. i .. ".json"
-    if love.filesystem.getInfo(path) then
+    if fileUtils.exists(path) then
       return path
     end
   end

--- a/client/src/FileUtils.lua
+++ b/client/src/FileUtils.lua
@@ -11,6 +11,19 @@ local fileUtils = {}
 fileUtils.SUPPORTED_IMAGE_FORMATS = {".png", ".jpg", ".jpeg"}
 fileUtils.SUPPORTED_SOUND_FORMATS = {".mp3", ".ogg", ".wav", ".flac", ".699", ".amf", ".ams", ".dbm", ".dmf", ".dsm", ".far", ".it", ".j2b", ".mdl", ".med", ".mod", ".mt2", ".mtm", ".okt", ".psm", ".s3m", ".stm", ".ult", ".umx", ".xm"}
 
+-- Wrapper for love.filesystem.exists that handles version compatibility
+-- In LÖVE 11.x, uses getInfo() to avoid deprecation warning
+-- In LÖVE 12.x+, uses exists() which is no longer deprecated
+---@param path string
+---@return boolean
+function fileUtils.exists(path)
+  if system.meetsLoveVersionRequirement(12, 0) then
+    return love.filesystem.exists(path)
+  else
+    return love.filesystem.getInfo(path) ~= nil
+  end
+end
+
 -- returns the directory items with a default filter and an optional filetype filter
 -- by default, filters out everything starting with __ and Mac's .DS_Store file
 -- optionally the result can be filtered to return only "file" or "directory" items
@@ -119,7 +132,7 @@ end
 ---@param file string
 ---@return table? # nil if the file could not be read or deserialization failed
 function fileUtils.readJsonFile(file)
-  if not love.filesystem.getInfo(file, "file") then
+  if not fileUtils.exists(file) then
     logger.debug("No file at specified path " .. file)
     return nil
   else
@@ -148,7 +161,7 @@ end
 ---@return love.Source?
 function fileUtils.loadSoundFromSupportExtensions(path_and_filename, streamed)
   for k, extension in ipairs(fileUtils.SUPPORTED_SOUND_FORMATS) do
-    if love.filesystem.exists(path_and_filename .. extension) then
+    if fileUtils.exists(path_and_filename .. extension) then
       return love.audio.newSource(path_and_filename .. extension, streamed and "stream" or "static")
     end
   end
@@ -229,7 +242,7 @@ end
 function fileUtils.getSoundFileName(soundName, path)
   local p = path .. "/" .. soundName
   for _, extension in pairs(fileUtils.SUPPORTED_SOUND_FORMATS) do
-    if love.filesystem.exists(p .. extension) then
+    if fileUtils.exists(p .. extension) then
       return soundName .. extension
     end
   end

--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -287,11 +287,11 @@ function Game:createDirectoriesIfNeeded()
 
   local oldServerDirectory = consts.SERVER_SAVE_DIRECTORY .. consts.LEGACY_SERVER_LOCATION
   local newServerDirectory = consts.SERVER_SAVE_DIRECTORY .. consts.SERVER_LOCATION
-  if not love.filesystem.getInfo(newServerDirectory) then
+  if not fileUtils.exists(newServerDirectory) then
     love.filesystem.createDirectory(newServerDirectory)
 
     -- Move the old user ID spot to the new folder (we won't delete the old one for backwards compatibility and safety)
-    if love.filesystem.getInfo(oldServerDirectory) then
+    if fileUtils.exists(oldServerDirectory) then
       local userID = save.read_user_id_file(consts.LEGACY_SERVER_LOCATION)
       save.write_user_id_file(userID, consts.SERVER_LOCATION)
     end

--- a/client/src/config.lua
+++ b/client/src/config.lua
@@ -164,7 +164,7 @@ config = {
         if read_data then
           -- do stuff using read_data.version for retrocompatibility here
 
-          if type(read_data.theme) == "string" and love.filesystem.getInfo(THEME_DIRECTORY_PATH .. read_data.theme .. "/config.json") then
+          if type(read_data.theme) == "string" and fileUtils.exists(THEME_DIRECTORY_PATH .. read_data.theme .. "/config.json") then
             configTable.theme = read_data.theme
           end
 

--- a/client/src/graphics/graphics_util.lua
+++ b/client/src/graphics/graphics_util.lua
@@ -60,7 +60,7 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
 
   local fileName = pathAndName .. scaleSuffixString .. extension
 
-  if love.filesystem.getInfo(fileName) then
+  if FileUtils.exists(fileName) then
     local result = GraphicsUtil.privateLoadImage(fileName)
     if result then
       assert(result:getDPIScale() == scale, "The image " .. pathAndName .. " didn't wasn't created with the scale: " .. scale .. " did you make sure the width and height are divisible by the scale?")

--- a/client/src/localization.lua
+++ b/client/src/localization.lua
@@ -4,6 +4,7 @@ local consts = require("common.engine.consts")
 local logger = require("common.lib.logger")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
 local class = require("common.lib.class")
+local fileUtils = require("client.src.FileUtils")
 
 -- Holds all the data for localizing the game
 Localization = {
@@ -90,7 +91,7 @@ function Localization.init(self)
   local i = 1
   local key = nil
   -- Process all the localization strings
-  if love.filesystem.getInfo(FILENAME) then
+  if fileUtils.exists(FILENAME) then
     for line in love.filesystem.lines(FILENAME) do
       if num_line == 1 then
         tokens = Localization.csv_line(line)

--- a/client/src/mods/ModLoader.lua
+++ b/client/src/mods/ModLoader.lua
@@ -173,7 +173,7 @@ local blackLists = {}
 function ModLoader.loadBlacklist(modType)
   local blackList = {}
   local path = modType.SAVE_DIR .. "/blacklist.txt"
-  if love.filesystem.getInfo(path, "file") then
+  if fileUtils.exists(path) then
     for line in love.filesystem.lines(path) do
       blackList[#blackList+1] = line
     end
@@ -241,7 +241,7 @@ function ModLoader.filterToVisible(modType, filtered, ids)
   local visible = {}
   local path = themes[config.theme].path .. "/" .. modType.SAVE_DIR .. ".txt"
 
-  if love.filesystem.getInfo(path, "file") then
+  if fileUtils.exists(path) then
     for line in love.filesystem.lines(path) do
       line = trim(line) -- remove whitespace
       -- found at least a valid mod in a $(modtype.TYPE).txt file

--- a/client/src/mods/Theme.lua
+++ b/client/src/mods/Theme.lua
@@ -507,8 +507,8 @@ function Theme:loadCards()
   -- Chain card loading
   -- load as many chain cards as there are available until 99
   -- we assume if the theme provided any chains, they want to control all of them so don't load backups
-  local hasChainCards = love.filesystem.getInfo(self.path .. "/chain")
-  local wantsBackupChainCards = hasChainCards == nil
+  local hasChainCards = fileUtils.exists(self.path .. "/chain")
+  local wantsBackupChainCards = not hasChainCards
   for i = 2, 13 do
     -- with backup from default theme
     self.images.IMG_cards[true][i] = self:load_theme_img("chain/chain" .. tostring(math.floor(i / 10)) .. tostring(i % 10) .. "")
@@ -822,7 +822,7 @@ end
 function Theme:loadDefaultStage()
   local stagePath = self.path .. "/default/stage"
   local defaultStage
-  if love.filesystem.getInfo(stagePath, "directory") then
+  if fileUtils.exists(stagePath) then
     defaultStage = require("client.src.mods.Stage")(stagePath, "__default")
     -- we don't want to do a full json init but we need to find out the music style of the default stage
     local read_data = fileUtils.readJsonFile(defaultStage.path .. "/config.json")

--- a/client/src/save.lua
+++ b/client/src/save.lua
@@ -16,14 +16,14 @@ function save.read_key_file()
   local filename
   local migrateInputs = false
 
-  if love.filesystem.getInfo("keysV3.json", "file") then
+  if FileUtils.exists("keysV3.json") then
     filename = "keysV3.json"
   else
     filename = "keysV2.txt"
     migrateInputs = true
   end
 
-  if not love.filesystem.getInfo(filename, "file") then
+  if not FileUtils.exists(filename) then
     return inputManager.inputConfigurations
   else
     local inputConfigs = FileUtils.readJsonFile(filename)
@@ -73,7 +73,7 @@ end
 local sep = package.config:sub(1, 1) --determines os directory separator (i.e. "/" or "\")
 
 function save.readAttackFile(path)
-  if love.filesystem.getInfo(path, "file") then
+  if FileUtils.exists(path) then
     local jsonData = love.filesystem.read(path)
     local trainingConf, position, errorMsg = json.decode(jsonData)
     if trainingConf then

--- a/client/src/scenes/OptionsMenu.lua
+++ b/client/src/scenes/OptionsMenu.lua
@@ -556,7 +556,7 @@ function OptionsMenu:loadModifyUserIdMenu()
   local modifyUserIdOptions = {}
   local userIDDirectories = fileUtils.getFilteredDirectoryItems("servers")
   for i = 1, #userIDDirectories do
-    if love.filesystem.getInfo("servers/" .. userIDDirectories[i] .. "/user_id.txt", "file") then
+    if fileUtils.exists("servers/" .. userIDDirectories[i] .. "/user_id.txt") then
       modifyUserIdOptions[#modifyUserIdOptions + 1] = ui.MenuItem.createButtonMenuItem(userIDDirectories[i], nil, false, function()
           GAME.navigationStack:push(SetUserIdMenu({serverIp = userIDDirectories[i]}))
         end)

--- a/client/src/scenes/StartUp.lua
+++ b/client/src/scenes/StartUp.lua
@@ -84,7 +84,7 @@ function StartUp:checkIfMigrationIsPossible()
 
   local os = love.system.getOS()
   if os == "Linux" or os == "OS X" then
-    if not love.filesystem.exists("conf.json") then
+    if not fileUtils.exists("conf.json") then
       local path = love.filesystem.getAppdataDirectory()
       if path:sub(-1) ~= "/" then
         path = path .. "/"
@@ -101,7 +101,7 @@ function StartUp:checkIfMigrationIsPossible()
         -- if we couldn't mount that directory, that means there is no old install
         logger.debug("No old install found")
       else
-        if love.filesystem.exists("oldInstall/conf.json") then
+        if fileUtils.exists("oldInstall/conf.json") then
           return path
         end
       end

--- a/testLauncher.lua
+++ b/testLauncher.lua
@@ -37,6 +37,7 @@ end
 require("client.src.globals")
 local system = require("client.src.system")
 local Game = require("client.src.Game")
+local fileUtils = require("client.src.FileUtils")
 
 function love.load()
   -- this is necessary setup of globals while non-client tests still depend on client components
@@ -179,7 +180,7 @@ function love.errorhandler(msg)
   if lldebugger then
     error(msg, 2)
   else
-    local crashInfo = love.filesystem.getInfo("test-crash.log")
+    local crashInfo = fileUtils.exists("test-crash.log")
     if crashInfo and system.supportsFileBrowserOpen() then
       local sep = package.config:sub(1, 1)
       love.system.openURL("file://"..love.filesystem.getRealDirectory("test-crash.log") .. sep .. "test-crash.log")

--- a/verificationLauncher.lua
+++ b/verificationLauncher.lua
@@ -29,9 +29,10 @@ require("common.lib.util")
 local logger = require("common.lib.logger")
 local verifier = require("common.tests.engine.IntegrityVerification")
 local system = require("client.src.system")
+local fileUtils = require("client.src.FileUtils")
 
 function love.load(arg)
-  if not love.filesystem.exists(OUTPUT) then
+  if not fileUtils.exists(OUTPUT) then
     love.filesystem.createDirectory(OUTPUT)
   end
 


### PR DESCRIPTION
add wrapper for love.filesystem.exists that handles version compatibility 
-- In LÖVE 11.x, uses getInfo() to avoid deprecation warning 
-- In LÖVE 12.x+, uses exists() which is no longer deprecated

it was undeprecated because its faster when you don't need file info