### PR TITLE
Only display a reason for leaving if a player left, not a spectator

### DIFF
--- a/client/src/network/NetClient.lua
+++ b/client/src/network/NetClient.lua
@@ -125,7 +125,12 @@ local function processLeaveRoomMessage(self, message)
       -- instead we actively abort the match ourselves
       self.room.match:abort()
       self.room.match:deinit()
-      transition = MessageTransition(love.timer.getTime(), 5, message.reason or "", false)
+
+      if message.reason then
+        -- the server sends a reason for leaveRoom only if a player (not a spectator) in the room leaves/crashes/disconnects
+        -- the other player and spectators should be informed why the room is being closed
+        transition = MessageTransition(love.timer.getTime(), 5, message.reason, false)
+      end
     end
 
     -- and then shutdown the room

--- a/server/Room.lua
+++ b/server/Room.lua
@@ -192,7 +192,7 @@ function Room:remove_spectator(spectator)
       self.spectators[i].state = "lobby"
       logger.debug(spectator.name .. " left " .. self.name .. " as a spectator")
       table.remove(self.spectators, i)
-      spectator:removeFromRoom(self, spectator.name .. " left")
+      spectator:removeFromRoom(self)
       lobbyChanged = true
       break
     end


### PR DESCRIPTION
Fixes #715 
Needs a server update to work but it is shippable independently, just won't fix the bug with the way it's done until the server update happened.