### PR TITLE
Don't load garbage for bundle characters

### DIFF
--- a/client/src/mods/Character.lua
+++ b/client/src/mods/Character.lua
@@ -335,7 +335,7 @@ function Character.graphics_init(self, full, yields)
       coroutine.yield()
     end
   end
-  if full then
+  if full and not self:isBundle() then
     self.garbagePrerenders = {}
 
     for width = 1, 6 do


### PR DESCRIPTION
Bundle characters explicitly don't load up the default character's fallback textures as character select fallback is assembled from bundle mods and ingame assets are never used.
Logically they also should not try to create garbage textures or load up telegraph images.

In the current version forced resizes, e.g. due to smash+C or automatic scale change, caused a crash as the reload explicitly tries to do a full load on the config character (which can be a bundle) and selected characters in ongoing matches (which cannot be a bundle). I think bundles are otherwise never even fully loaded which is why this only occurs in said reload scenarios.