### PR TITLE
Fix username changing

### DIFF
--- a/client/src/developer.lua
+++ b/client/src/developer.lua
@@ -48,6 +48,7 @@ function developerTools.processArgs(args)
   end
 end
 
+local realId = nil
 local realName = nil
 
 function developerTools.wrapUsernameConfig(customUsername)
@@ -81,8 +82,19 @@ function developerTools.wrapUserIDRead(customUserID)
   logger.debug("Overwriting userID with command line argument")
 
   local save = require("client.src.save")
+  local readId = save.read_user_id_file
   save.read_user_id_file = function(serverIP)
+    realId = readId(serverIP)
     return customUserID
+  end
+
+  local writeId = save.write_user_id_file
+  save.write_user_id_file = function(userID, serverIP)
+    if userID == customUserID then
+      userID = realId
+    end
+    assert(userID ~= nil)
+    writeId(userID, serverIP)
   end
 end
 

--- a/client/src/developer.lua
+++ b/client/src/developer.lua
@@ -1,5 +1,6 @@
 local system = require("client.src.system")
 local DebugSettings = require("client.src.debug.DebugSettings")
+local logger = require("common.lib.logger")
 ---@diagnostic disable: duplicate-set-field
 
 -- Put any local development changes you need in here that you don't want commited.
@@ -38,19 +39,20 @@ function developerTools.processArgs(args)
       GAME_UPDATER = require("updater.gameUpdater")
     else
       for match in string.gmatch(value, "user%-id=(.*)") do
-        CUSTOM_USER_ID = match
+        developerTools.customUserID = match
       end
       for match in string.gmatch(value, "username=(.*)") do
-        CUSTOM_USERNAME = match
+        developerTools.customUsername = match
       end
     end
   end
 end
 
-local realId
-local realName
+local realName = nil
 
-function developerTools.wrapConfig()
+function developerTools.wrapUsernameConfig(customUsername)
+  assert(customUsername)
+
   local read = readConfigFile
   local write = write_conf_file
 
@@ -58,38 +60,38 @@ function developerTools.wrapConfig()
     ---@type UserConfig
     c = read(c)
     realName = c.name
-    c.name = CUSTOM_USERNAME or realName
+    logger.debug("Original username was " .. realName)
+    c.name = customUsername
+    logger.debug("Overwriting name to custom username: " .. c.name)
   end
 
   write_conf_file = function()
-    if config.name == CUSTOM_USERNAME then
+    if config.name == customUsername then
+      assert(realName)
       config.name = realName
     end
     write()
-    config.name = CUSTOM_USERNAME or realName
+    config.name = customUsername
   end
 end
 
-function developerTools.wrapPersistence()
+function developerTools.wrapUserIDRead(customUserID)
+  assert(customUserID)
+
+  logger.debug("Overwriting userID with command line argument")
+
   local save = require("client.src.save")
-
-  local readId = save.read_user_id_file
   save.read_user_id_file = function(serverIP)
-    realId = readId(serverIP)
-    return CUSTOM_USER_ID or realId
-  end
-
-  local writeId = save.write_user_id_file
-  save.write_user_id_file = function(userID, serverIP)
-    if userID == CUSTOM_USER_ID then
-      userID = realId
-    end
-    writeId(userID, serverIP)
+    return customUserID
   end
 end
 
 developerTools.processArgs(arg)
-developerTools.wrapConfig()
-developerTools.wrapPersistence()
+if developerTools.customUsername then
+  developerTools.wrapUsernameConfig(developerTools.customUsername)
+end
+if developerTools.customUserID then
+  developerTools.wrapUserIDRead(developerTools.customUserID)
+end
 
 return developerTools


### PR DESCRIPTION
We were accidentally overriding the functions even when you didn't have arguments passed in.

Now only add them if set, and don't make extra unneeded globals.