### PR TITLE
Improve Server Launch Setup

### DIFF
--- a/common/lib/logger.lua
+++ b/common/lib/logger.lua
@@ -14,49 +14,54 @@ local logger = {
   messageBuffer = RingBuffer(2048)
 }
 
-logger.TRACE = 0 -- Log something that is very detailed verbose debug logging
-logger.DEBUG = 1 -- Log something that is only useful when debugging
-logger.INFO = 2 -- Log something that is useful in most normal conditions
-logger.WARN = 3 -- Log something that could be a problem
-logger.ERROR = 4 -- Log something that definitely is a problem
+---@enum LogLevel
+logger.levels = {
+  TRACE = 0, -- Log something that is very detailed verbose debug logging
+  DEBUG = 1, -- Log something that is only useful when debugging
+  INFO = 2, -- Log something that is useful in most normal conditions
+  WARN = 3, -- Log something that could be a problem
+  ERROR = 4 -- Log something that definitely is a problem
+}
 
-local LOG_LEVEL = logger.DEBUG
+---@type LogLevel
+local LOG_LEVEL = logger.levels.DEBUG
 
+---@param level LogLevel use logger.levels. to access presets
 function logger.setLogLevel(level)
   LOG_LEVEL = level
 end
 
 -- See comments above about when you should use each logging level
 function logger.trace(msg)
-  if LOG_LEVEL <= logger.TRACE then
+  if LOG_LEVEL <= logger.levels.TRACE then
     direct_log("TRACE", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.debug(msg)
-  if LOG_LEVEL <= logger.DEBUG then
+  if LOG_LEVEL <= logger.levels.DEBUG then
     direct_log("DEBUG", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.info(msg)
-  if LOG_LEVEL <= logger.INFO then
+  if LOG_LEVEL <= logger.levels.INFO then
     direct_log(" INFO", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.warn(msg)
-  if LOG_LEVEL <= logger.WARN then
+  if LOG_LEVEL <= logger.levels.WARN then
     direct_log(" WARN", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.error(msg)
-  if LOG_LEVEL <= logger.ERROR then
+  if LOG_LEVEL <= logger.levels.ERROR then
     direct_log("ERROR", msg);
   end
 end

--- a/common/lib/logger.lua
+++ b/common/lib/logger.lua
@@ -24,44 +24,44 @@ logger.levels = {
 }
 
 ---@type LogLevel
-local LOG_LEVEL = logger.levels.DEBUG
+logger.logLevel = logger.levels.DEBUG
 
 ---@param level LogLevel use logger.levels. to access presets
 function logger.setLogLevel(level)
-  LOG_LEVEL = level
+  logger.logLevel = level
 end
 
 -- See comments above about when you should use each logging level
 function logger.trace(msg)
-  if LOG_LEVEL <= logger.levels.TRACE then
+  if logger.logLevel <= logger.levels.TRACE then
     direct_log("TRACE", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.debug(msg)
-  if LOG_LEVEL <= logger.levels.DEBUG then
+  if logger.logLevel <= logger.levels.DEBUG then
     direct_log("DEBUG", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.info(msg)
-  if LOG_LEVEL <= logger.levels.INFO then
+  if logger.logLevel <= logger.levels.INFO then
     direct_log(" INFO", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.warn(msg)
-  if LOG_LEVEL <= logger.levels.WARN then
+  if logger.logLevel <= logger.levels.WARN then
     direct_log(" WARN", msg);
   end
 end
 
 -- See comments above about when you should use each logging level
 function logger.error(msg)
-  if LOG_LEVEL <= logger.levels.ERROR then
+  if logger.logLevel <= logger.levels.ERROR then
     direct_log("ERROR", msg);
   end
 end

--- a/serverLauncher.lua
+++ b/serverLauncher.lua
@@ -1,6 +1,19 @@
+local logger = require("common.lib.logger")
+
 if arg[1] == "debug" then
   -- for debugging in visual studio code
-  pcall(function() require("lldebugger").start() end)
+  if os.getenv("LOCAL_LUA_DEBUGGER_VSCODE") == "1" then
+    -- VS Code / VS Codium
+    require("lldebugger").start()
+  elseif pcall(function() require("mobdebug") end) then
+    -- ZeroBrane
+    -- afaik there is no good way to detect whether the game was started with zerobrane other than trying the require and succeeding
+    require("mobdebug").start()
+    require('mobdebug').coro()
+  end
+  logger.setLogLevel(logger.levels.DEBUG)
+else
+  logger.setLogLevel(logger.levels.INFO)
 end
 
 -- We must launch the server from the root directory so all the requires are the right path relatively.

--- a/testLauncher.lua
+++ b/testLauncher.lua
@@ -29,9 +29,9 @@ local logger = require("common.lib.logger")
 
 -- Set log level based on debug argument
 if arg[2] == "debug" then
-  logger.setLogLevel(logger.DEBUG)
+  logger.setLogLevel(logger.levels.DEBUG)
 else
-  logger.setLogLevel(logger.INFO)
+  logger.setLogLevel(logger.levels.INFO)
 end
 
 require("client.src.globals")


### PR DESCRIPTION
Logger now has its log levels clarified via an enum that gives a hint when logger.setLogLevel is used.
Server automatically sets the debug level to INFO on startup unless started with the debug argument