### PR TITLE
Validate classic mode combo sfx to not have gaps

### DIFF
--- a/client/src/mods/Character.lua
+++ b/client/src/mods/Character.lua
@@ -540,6 +540,26 @@ function Character:validate()
     return valid, err
   end
 
+  if self.combo_style == comboStyle.classic then
+    local files = fileUtils.getFilteredDirectoryItems(self.path, "file")
+    local comboFiles = fileUtils.getMatchingFiles(files, "combo", fileUtils.SUPPORTED_SOUND_FORMATS)
+    local indices = {}
+    for _, comboFile in ipairs(comboFiles) do
+      local index = tonumber(string.match(comboFile, "%d+", 6))
+      -- first one is typically unnumbered
+      indices[#indices+1] = index or 1
+    end
+
+    table.sort(indices)
+    local lastValue = 0
+    for _, index in ipairs(indices) do
+      if index - 1 > lastValue then
+        return false, "Characters with combo_style \"classic\" need to have their combo SFX sequentially numbered with no gaps. Missing combo" .. tostring(lastValue + 1)
+      end
+      lastValue = index
+    end
+  end
+
   return true
 end
 

--- a/client/src/scenes/ModValidationScene.lua
+++ b/client/src/scenes/ModValidationScene.lua
@@ -3,6 +3,7 @@ local Scene = require("client.src.scenes.Scene")
 local ui = require("client.src.ui")
 local ModLoader = require("client.src.mods.ModLoader")
 local inputs = require("client.src.inputManager")
+local system = require("client.src.system")
 
 local SCROLL_STEP = 14
 
@@ -14,7 +15,12 @@ function(self, sceneParams)
     text = text .. "Failed to validate mod " .. mod.id .. " at path " .. mod.path .. " for the following reason:\n" .. reason .. "\n"
   end
 
-  text = text .. "\n\nThe mentioned mods have been disabled\nPress Escape to continue"
+  text = text .. "\n\nThe mentioned mods have been disabled"
+  if system.isMobileOS() then
+    text = text .. "\nPress the Back button to continue"
+  else
+    text = text .. "\nPress Escape to continue"
+  end
 
   local modWarningLabel = ui.Label({text = text, translate = false, x = 10})
   self.scrollContainer:addChild(modWarningLabel)

--- a/docs/characters.md
+++ b/docs/characters.md
@@ -226,7 +226,7 @@ The default option if not specified. Also deprecated, please use per_chain style
 	x4 plays "chain2",  
 	x5 plays "chain_echo",   
 	x6+ plays "chain2_echo"  
-Due to backwards compatibility reason the classic system remains as the default.  
+Due to backwards compatibility reasons the classic system remains as the default.  
 If you wish to use classic style chain sounds, you can use the per_chain system.  
 Simply rename the classic system's  
 "chain" as "chain2",  
@@ -255,7 +255,8 @@ Available options are "classic" and "per_combo".
 ##### classic
 
 The default option if not specified.  
-For combos of any size this will play the SFX "combo" (,"combo2", "combo3", ...) [selected at random if more than one]
+For combos of any size this will play the SFX "combo1" (,"combo2", "combo3", ...) [selected at random if more than one exists]  
+Combos **need** to be numbered sequentially, you cannot skip any number. You may use "combo" instead of "combo1" (legacy support).
 
 ##### per_combo
 


### PR DESCRIPTION
Fixes #735 
Also clarifies the requirement in the documentation
Adjust continuation text of the ModValidationScene for non-keyboard systems (Android sends presses of the back button as "escape")