### PR TITLE
add input debug menu

### DIFF
--- a/client/src/scenes/InputConfigMenu.lua
+++ b/client/src/scenes/InputConfigMenu.lua
@@ -6,6 +6,7 @@ local inputManager = require("client.src.inputManager")
 local class = require("common.lib.class")
 local InputConfigSlider = require("client.src.ui.InputConfigSlider")
 local KeyBindingMenuItem = require("client.src.ui.KeyBindingMenuItem")
+local InputDebugMenu = require("client.src.scenes.InputDebugMenu")
 
 -- Sometimes controllers register buttons as "pressed" even though they aren't. If they have been pressed longer than this they don't count.
 local MAX_PRESS_DURATION = 0.5
@@ -328,6 +329,7 @@ function InputConfigMenu:loadUI()
   menuOptions[#menuOptions + 1] = ui.MenuItem.createButtonMenuItem("op_all_keys", nil, nil, function() self:setAllKeysStart() end)
   menuOptions[#menuOptions + 1] = ui.MenuItem.createButtonMenuItem("Clear All Inputs", nil, false, function() self:clearAllInputs() end)
   menuOptions[#menuOptions + 1] = ui.MenuItem.createButtonMenuItem("Reset Keys To Default", nil, false, function() self:resetToDefault() end)
+  menuOptions[#menuOptions + 1] = ui.MenuItem.createButtonMenuItem("Debug Input", nil, false, function() GAME.navigationStack:push(InputDebugMenu({})) end)
 
   -- Back button with warning for incomplete configurations
   self.backMenuItem = ui.MenuItem.createButtonMenuItem("back", nil, nil, self:createExitMenuFunction())

--- a/client/src/scenes/InputDebugMenu.lua
+++ b/client/src/scenes/InputDebugMenu.lua
@@ -1,0 +1,143 @@
+local Scene = require("client.src.scenes.Scene")
+local class = require("common.lib.class")
+local inputManager = require("client.src.inputManager")
+local joystickManager = require("common.lib.joystickManager")
+local InputConfiguration = require("client.src.input.InputConfiguration")
+local consts = require("common.engine.consts")
+
+local MAX_LOG_ENTRIES = 20
+
+local InputDebugMenu = class(function(self, sceneParams)
+  self.music = "main"
+  self.pressLog = {}
+  self.prevDown = {}
+end, Scene)
+
+InputDebugMenu.name = "InputDebugMenu"
+
+local function getDisplayName(rawKey)
+  local guid, _, buttonId = InputConfiguration.parseBindingString(rawKey)
+  if not guid then
+    return rawKey  -- keyboard key, name is the key itself
+  end
+
+  for _, joystick in ipairs(love.joystick.getJoysticks()) do
+    if joystick:getGUID() == guid then
+      return InputConfiguration.getButtonNameFromMapping(joystick, buttonId)
+    end
+  end
+  return buttonId
+end
+
+local function getControllerName(rawKey)
+  local guid = InputConfiguration.parseBindingString(rawKey)
+  if not guid then
+    return nil
+  end
+  return joystickManager.guidToName[guid] or guid
+end
+
+local function getBoundActions(rawKey)
+  local results = {}
+  for i, config in ipairs(inputManager.inputConfigurations) do
+    for _, keyName in ipairs(consts.KEY_NAMES) do
+      if config[keyName] == rawKey then
+        results[#results + 1] = "cfg" .. i .. "." .. keyName
+      end
+    end
+  end
+  return #results > 0 and table.concat(results, "  ") or "(unbound)"
+end
+
+function InputDebugMenu:update(dt)
+  if inputManager.allKeys.isDown["escape"] then
+    GAME.navigationStack:pop()
+    return
+  end
+
+  local currentDown = {}
+  for key, _ in pairs(inputManager.allKeys.isDown) do
+    currentDown[key] = true
+    if not self.prevDown[key] then
+      local entry = {
+        raw = key,
+        display = getDisplayName(key),
+        controller = getControllerName(key),
+        actions = getBoundActions(key),
+      }
+      table.insert(self.pressLog, 1, entry)
+      if #self.pressLog > MAX_LOG_ENTRIES then
+        self.pressLog[MAX_LOG_ENTRIES + 1] = nil
+      end
+    end
+  end
+  self.prevDown = currentDown
+end
+
+function InputDebugMenu:draw()
+  themes[config.theme].images.bg_main:draw()
+
+  love.graphics.setColor(0, 0, 0, 0.6)
+  love.graphics.rectangle("fill", 10, 10, consts.CANVAS_WIDTH - 20, consts.CANVAS_HEIGHT - 20)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  local x = 20
+  local y = 20
+  local lineH = 18
+
+  love.graphics.print("INPUT DEBUG  (keyboard Esc to return)", x, y)
+  y = y + lineH + 4
+
+  -- Connected devices section
+  love.graphics.setColor(0.7, 0.9, 1, 1)
+  love.graphics.print("CONNECTED DEVICES:", x, y)
+  y = y + lineH
+  local joysticks = love.joystick.getJoysticks()
+  if #joysticks == 0 then
+    love.graphics.setColor(0.6, 0.6, 0.6, 1)
+    love.graphics.print("  (none)", x, y)
+    y = y + lineH
+  else
+    for _, joystick in ipairs(joysticks) do
+      local guid = joystick:getGUID()
+      local slot = joystickManager.guidsToJoysticks[guid] and joystickManager.guidsToJoysticks[guid][joystick:getID()] or "?"
+      local isGP = joystick:isGamepad() and "gamepad" or "joystick"
+      love.graphics.setColor(1, 0.8, 0.4, 1)
+      love.graphics.print(string.format("  [%s] slot=%s  guid=%s  %s", joystick:getName(), tostring(slot), guid, isGP), x, y)
+      y = y + lineH
+    end
+  end
+
+  love.graphics.setColor(0.5, 0.5, 0.5, 1)
+  love.graphics.line(x, y, consts.CANVAS_WIDTH - 20, y)
+  y = y + 6
+
+  -- Column headers 
+  love.graphics.setColor(0.7, 0.9, 1, 1)
+  love.graphics.print("RAW KEY", x, y)
+  love.graphics.print("DISPLAY", x + 340, y)
+  love.graphics.print("CONTROLLER", x + 440, y)
+  love.graphics.print("BOUND TO", x + 620, y)
+  y = y + lineH
+
+  if #self.pressLog == 0 then
+    love.graphics.setColor(0.8, 0.8, 0.5, 1)
+    love.graphics.print("(press any button...)", x, y)
+  else
+    for i, entry in ipairs(self.pressLog) do
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.print(entry.raw, x, y)
+      love.graphics.setColor(0.4, 1, 0.4, 1)
+      love.graphics.print(entry.display, x + 340, y)
+      love.graphics.setColor(1, 0.8, 0.4, 1)
+      love.graphics.print(entry.controller or "keyboard", x + 440, y)
+      love.graphics.setColor(0.8, 0.8, 1, 1)
+      love.graphics.print(entry.actions, x + 620, y)
+      y = y + lineH
+    end
+  end
+
+  love.graphics.setColor(1, 1, 1, 1)
+end
+
+return InputDebugMenu


### PR DESCRIPTION
Disclaimer: had used Claude for a first pass at the menu, and feels like more code than it needs to be. Would appreciate any pointers

This might need to be behind a debug flag, but it does two things:

- shows you what controllers are considered connected
- shows raw key inputs and how they're interpreted by InputManager

This helped me debug an annoying issue on inputs that I was experiencing on MacOS

<img width="959" height="766" alt="image" src="https://github.com/user-attachments/assets/5437ba7a-651c-4211-9262-1949eba139a1" />

<img width="1388" height="842" alt="image" src="https://github.com/user-attachments/assets/0048249f-855a-44d6-8fd4-166cd58b8ae4" />
